### PR TITLE
Fix package-name drift scanner: add governance/ scan surface (119-A gap)

### DIFF
--- a/scripts/check-package-name-drift.js
+++ b/scripts/check-package-name-drift.js
@@ -7,7 +7,9 @@
  * the scope declared in package.json. Exits non-zero if drift is detected.
  *
  * Surfaces scanned (per Spec 101 design-outline):
- *   - .kiro/steering/   — steering docs (Civitas-governed)
+ *   - governance/       — MCP-served steering corpus (81 docs; relocated here
+ *                         from .kiro/steering/ by Spec 119-A)
+ *   - .kiro/steering/   — always-loaded identity docs (9 docs remaining post-119-A)
  *   - src/              — functional source code and component READMEs
  *   - product-template/ — consumer-facing agent prompts
  *   - .kiro/agents/     — local development agent prompts
@@ -50,7 +52,8 @@ const colors = {
  * Directories to scan for drift. Paths relative to repo root.
  */
 const SCAN_DIRS = [
-  '.kiro/steering',
+  'governance',      // MCP-served steering corpus (relocated from .kiro/steering by Spec 119-A)
+  '.kiro/steering',  // always-loaded identity docs remaining post-119-A
   'src',
   'product-template',
   '.kiro/agents',


### PR DESCRIPTION
The drift scanner scanned .kiro/steering/ but not governance/. After Spec 119-A relocated 81 docs from .kiro/steering/ → governance/, those docs fell out of drift coverage — a silent hole (missed drift), not a false alarm. The 119-A N-1 repoint sweep fixed the metadata validator / governance-check / detect-affected scripts to scan both roots but missed this scanner.

Fix: add 'governance' to SCAN_DIRS (keeping '.kiro/steering' for the 9 identity docs that remain there) and update the surfaces header comment. Mirrors the metadata-validator both-roots repoint.

Verified:
- Clean run exits 0 (governance/ holds 75 correctly-scoped @3fn/core refs; no false drift surfaced, build not broken).
- Injected a temporary @wrongscope/core into governance/ → scanner now catches it (exit 1); removed → exit 0. Confirms the surface is live (file count rose to 1506 scanned).

Not a 119-B deferred obligation: OB-1's bundle deferred only the cross-reference scanner (scan-cross-references.sh, pending parser id-awareness) — this package-name scanner was simply missed in the sweep.