### PR TITLE
Reconcile 2 process docs: bare-id cross-refs + hook-ops PR-gate scope…

### DIFF
--- a/governance/Process-Cross-Reference-Standards.md
+++ b/governance/Process-Cross-Reference-Standards.md
@@ -8,7 +8,7 @@ description: Cross-reference standards for documentation — formatting rules, c
 # Process-Cross-Reference-Standards
 
 **Date**: 2026-01-03
-**Last Reviewed**: 2026-01-03
+**Last Reviewed**: 2026-07-09
 **Purpose**: Comprehensive guide for creating and maintaining cross-references in documentation
 **Organization**: process-standard
 **Scope**: cross-project
@@ -34,7 +34,7 @@ Cross-references MUST be used in the following documentation types:
 - **Completion Documents**: Task completion documentation in `.kiro/specs/[spec-name]/completion/`
 - **README Files**: Project and directory README files that provide navigation and context
 - **Overview Documents**: Master documents that map components to their documentation (e.g., `docs/token-system-overview.md`)
-- **Process Documentation**: Standards and methodology documents in `.kiro/steering/` and `docs/processes/`
+- **Process Documentation**: Standards and methodology documents in the MCP-served governance corpus (`governance/`), the always-loaded identity docs (`.kiro/steering/`), and `docs/processes/`
 
 **Rationale**: These are documentation artifacts where cross-references add value by helping readers discover related information and navigate between connected concepts.
 
@@ -113,11 +113,24 @@ export const TypographyTokens = {
 
 ## How to Format Cross-References
 
-Cross-references should follow consistent formatting patterns to ensure clarity and maintainability.
+Cross-references should follow consistent formatting patterns to ensure clarity and maintainability. **Which pattern applies depends on what you are linking to** — there are two reference classes:
+
+### Two Reference Classes (pick by target)
+
+| Target | How to reference | Example |
+|--------|------------------|---------|
+| **Steering / governance corpus** — an MCP-served doc that carries an `id:` (the docs under `governance/`, plus the 9 identity docs under `.kiro/steering/`) | **Bare-`id`** markdown link: `[Human Label](doc-id)` — the target's `id`, no path, no `.md` | `[Token Governance](token-governance)` |
+| **Spec-local / repo-file** — spec artifacts (requirements/design/tasks/completion docs, spec guides), READMEs, and other repo files that are **not** `id`-indexed | **Relative path** markdown link (see "Relative Path Usage" below) | `[Design Decisions](../design.md#design-decisions)` |
+
+**Why the split.** Spec 119-A gave every doc in the MCP-served corpus a stable, relocation-independent `id` and made bare-`id` the addressing form (226 intra-corpus refs migrated). An `id`-addressed link survives file moves because the `id` — not the path — is the address. Spec artifacts and loose repo files carry no `id`, so relative paths remain their correct form.
+
+**The addressing grammar is owned elsewhere — do not re-derive it here.** The canonical source for the `id` form, the composite `docid#sectionid` section grammar, kebab-case filenames, and `aliases` is [Steering Addressing Conventions](steering-addressing-conventions). This document governs cross-reference *practice* (when to link, link-text quality, anti-patterns, maintenance); it defers the *grammar* to that doc so the two never drift.
+
+> **Tooling caveat (119-B OB-1).** Bare-`id` cross-refs **resolve** correctly (resolver strategy-1), but the cross-reference *parser* still only enumerates `.md`-suffixed targets, so `list_cross_references` and the `crossReferences` map currently under-count bare-`id` links. Enumeration parity is deferred to 119-B OB-1. Until then, do not treat an empty `list_cross_references` result as proof a doc has no inbound links.
 
 ### Relative Path Usage
 
-Always use relative paths from the current document location. Relative paths ensure links remain valid when the repository structure changes or when viewing documentation in different contexts.
+For **spec-local and repo-file references** (the second class above), use relative paths from the current document location. Relative paths ensure these links remain valid when viewed across different contexts. (For steering/governance-corpus targets, use the bare-`id` form instead — see the table above.)
 
 **Pattern**: Use `../` to navigate up directories and `./` for same-directory references
 
@@ -611,7 +624,7 @@ Strategic Flexibility Guide.
 
 When files are moved during organization:
 
-1. Update all cross-reference links to reflect new locations
+1. **Bare-`id` references to steering/governance-corpus docs need no update** — the `id` is the address, so it survives the move (this move-resilience is the reason 119-A adopted `id`-addressing). Update the *relative-path* references (spec-local / repo-file links) to reflect new locations.
 2. Verify bidirectional links remain consistent
 3. Test navigation by clicking links in rendered markdown
 4. Document any broken links and fix them immediately
@@ -621,9 +634,11 @@ When files are moved during organization:
 Periodically validate cross-reference integrity:
 
 - Verify all links resolve to existing documents
-- Check that relative paths are correct from document location
+- Check that relative paths are correct from document location (bare-`id` links resolve by `id`, not path, so there is no path to verify — confirm the `id` exists)
 - Confirm section anchors exist in target documents
 - Test navigation efficiency (related docs reachable in 2 clicks or less)
+
+> **Caveat (119-B OB-1):** automated link-graph tooling built on `list_cross_references` currently under-counts bare-`id` links (the parser enumerates only `.md`-suffixed targets). Until OB-1 lands, supplement automated enumeration with a text search for bare-`id` targets when auditing a doc's inbound/outbound links.
 
 ### Navigation as Aid, Not Dependency
 
@@ -654,12 +669,14 @@ Cross-references should be navigation aids, not content dependencies:
 
 ## Related Documentation
 
-- **File Organization Standards** - Metadata and directory structure
-- **Completion Documentation Guide** - Completion doc cross-reference patterns
-- **Development Workflow** - Task completion workflow
+- [Steering Addressing Conventions](steering-addressing-conventions) - **Canonical** `id` / `docid#sectionid` grammar, filename and `aliases` conventions (this doc defers the grammar there)
+- [Process File Organization](process-file-organization) - Metadata and directory structure
+- [Completion Documentation Guide](completion-documentation-guide) - Completion doc cross-reference patterns
+- [Process Development Workflow](process-development-workflow) - Task completion workflow
 
-**MCP Queries**:
+**MCP Queries** (bare-`id` in the `path` argument — the resolver addresses by `id`):
 ```
-get_section({ path: ".kiro/steering/Process-File-Organization.md", heading: "Required Metadata Fields" })
-get_document_full({ path: ".kiro/steering/Completion Documentation Guide.md" })
+get_section({ path: "steering-addressing-conventions", heading: "Convention 2: Composite `docid#sectionid` Addressing Grammar" })
+get_section({ path: "process-file-organization", heading: "Required Metadata Fields" })
+get_document_full({ path: "completion-documentation-guide" })
 ```

--- a/governance/Process-Hook-Operations.md
+++ b/governance/Process-Hook-Operations.md
@@ -8,7 +8,7 @@ description: Agent hook operational guidance — dependency chains, execution or
 # Hook Operations Guide
 
 **Date**: 2026-01-04
-**Last Reviewed**: 2026-01-04
+**Last Reviewed**: 2026-07-09
 **Purpose**: Comprehensive operational guidance for agent hook dependency chains, troubleshooting, and best practices
 **Organization**: process-standard
 **Scope**: cross-project
@@ -18,6 +18,16 @@ description: Agent hook operational guidance — dependency chains, execution or
 ## Overview
 
 This document provides detailed operational guidance for working with Kiro agent hooks. It covers dependency chain behavior, troubleshooting procedures, and best practices for reliable automation.
+
+> ## ⚠️ Scope & runtime — read before applying any of this
+>
+> **1. This describes a Kiro-IDE-only mechanism.** The "agent hooks" here are the Kiro event-hook runtime — `.kiro/agent-hooks/*.json` configs fired by the Kiro IDE on `taskStatusChange` events. **Claude Code has no equivalent event-hook system** (the same runtime gap that the always-layer has under CC — see 122 / OB-7). Under Claude Code none of these hooks fire; file organization and any release steps are performed by explicit tooling/CLI steps, not by IDE events. Read every "hooks fire on task completion" statement below as *Kiro-runtime behavior*, not a cross-runtime guarantee.
+>
+> **2. "Task completion" now means merge (125-A PR-gate).** Since the ratified 125-A workflow, a task is accepted when its unit's **PR is merged** — not when a local status flips. The completion tool is `./.kiro/hooks/complete-task.sh` (opens the PR), which **superseded** the old commit-on-completion tooling. Work reaches `main` only through a merged, branch-protected PR. So the troubleshooting guidance below that frames "direct git commits" as *bypassing hooks* (versus using the `taskStatus` tool) is **Kiro-IDE-specific and predates the branch→PR→merge flow** — under the current workflow, committing and pushing a branch is a *correct, expected* step, not an error to avoid.
+>
+> **3. Release detection here is historical.** As the frontmatter notes, the release system was rebuilt in Spec 065 into an on-demand CLI (`src/tools/release/`); the release-detection-on-task-completion hook content below is retained for Kiro-hook operational history. See [Release Management System](release-management-system) for the current architecture.
+>
+> This doc is preserved for Kiro-runtime hook operations and history. A cross-runtime rework belongs with the 122 agent-generator work (OB-7), not here.
 
 **When to use this document**:
 - Debugging hook issues or automation failures
@@ -508,6 +518,8 @@ ls -la .kiro/release-triggers/
    # Wrong approach (bypasses hooks)
    # git commit -m "message" && git push
    ```
+
+   > **Kiro-runtime framing only (see the Scope banner).** "`git commit && push` bypasses hooks" is true *only* of the Kiro IDE event mechanism. Under the 125-A PR-gate workflow, committing and pushing a branch is the **correct** step — subtask/parent work reaches `main` through a merged PR, and `taskStatus` marks completion *on the branch*. This "wrong approach" label applies to Kiro hook-triggering, not to the git workflow itself.
 
 2. **Verify task status changed**: Check tasks.md to confirm task is marked `[x]`
 


### PR DESCRIPTION
… (Unit B)

Civitas health-check follow-up (findings § 3). Both docs are Thurgood's governance-process domain; flagged as drifted at the 2026-07-08 triage.

Process-Cross-Reference-Standards.md — teach the 119-A bare-`id` convention without over-converting still-valid relative links:
- Added a "Two Reference Classes" rule: steering/governance-corpus targets (id-indexed) use bare-`id` links [Label](doc-id); spec-local/repo-file targets (no id) keep relative paths. Qualified the old "always use relative paths" accordingly.
- Deferred the addressing GRAMMAR to the canonical [Steering Addressing Conventions] doc (this doc owns cross-ref *practice*, not grammar) — avoids a competing standard / cross-surface drift.
- Reconciled maintenance: id-addressed refs are move-resilient (no update after file moves); noted the 119-B OB-1 caveat that list_cross_references under-counts bare-id links until the parser is id-aware.
- Fixed the stale ".kiro/steering/" location line; converted the doc's own footer MCP-query examples to id-form so it models what it teaches.

Process-Hook-Operations.md — bounded fix + scope note (not a rewrite):
- Added a Scope & runtime banner: this is the Kiro-IDE-only agent-hook runtime (no Claude Code equivalent — 122/OB-7 territory); "task completion" now means MERGE under the 125-A PR-gate, and complete-task.sh superseded the commit-on-completion tooling; release detection is historical (Spec 065 on-demand CLI).
- Annotated the one line that now actively contradicts the flow (the "git commit && push = wrong" example) to clarify branch commit+push is correct under the PR-gate; Kiro-hook-bypass framing is IDE-only.

Both Last Reviewed → 2026-07-09; validator: 0 errors. All introduced bare-id links verified to resolve.