### PR TITLE
Fix package.json exports: order `types` condition first (clears 20 es…

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,42 +42,42 @@
   ],
   "exports": {
     ".": {
-      "import": "./dist/browser/designerpunk.esm.js",
-      "types": "./dist/browser-entry.d.ts"
+      "types": "./dist/browser-entry.d.ts",
+      "import": "./dist/browser/designerpunk.esm.js"
     },
     "./components": {
-      "import": "./dist/browser/designerpunk.esm.js",
-      "types": "./dist/browser-entry.d.ts"
+      "types": "./dist/browser-entry.d.ts",
+      "import": "./dist/browser/designerpunk.esm.js"
     },
     "./tokens.css": "./dist/DesignTokens.web.css",
     "./component-tokens.css": "./dist/ComponentTokens.web.css",
     "./config": {
+      "types": "./dist/config/index.d.ts",
       "import": "./dist/config/index.js",
-      "require": "./dist/config/index.js",
-      "types": "./dist/config/index.d.ts"
+      "require": "./dist/config/index.js"
     },
     "./types": {
+      "types": "./dist/types/index.d.ts",
       "import": "./dist/types/index.js",
-      "require": "./dist/types/index.js",
-      "types": "./dist/types/index.d.ts"
+      "require": "./dist/types/index.js"
     },
     "./build": {
+      "types": "./dist/build/tokens/index.d.ts",
       "import": "./dist/build/tokens/index.js",
-      "require": "./dist/build/tokens/index.js",
-      "types": "./dist/build/tokens/index.d.ts"
+      "require": "./dist/build/tokens/index.js"
     },
     "./blend": {
+      "types": "./dist/blend/index.d.ts",
       "import": "./dist/blend/index.js",
-      "require": "./dist/blend/index.js",
-      "types": "./dist/blend/index.d.ts"
+      "require": "./dist/blend/index.js"
     },
     "./jest-preset": {
       "require": "./dist/testing/jest-preset.js"
     },
     "./testing": {
+      "types": "./dist/testing/index.d.ts",
       "import": "./dist/testing/index.js",
-      "require": "./dist/testing/index.js",
-      "types": "./dist/testing/index.d.ts"
+      "require": "./dist/testing/index.js"
     },
     "./grid.css": "./src/styles/responsive-grid.css",
     "./fonts/inter.css": "./src/assets/fonts/inter/inter.css",


### PR DESCRIPTION
…build warnings)

esbuild warned ×20 that the `types` condition "will never be used as it comes after both import and require" — condition matching is first-match- wins, so a `types` placed after `import`/`require` is unreachable, and TS consumers of those subpaths were resolving declarations only via .d.ts file-adjacency (fragile), not the declared condition.

Reordered `types` first across the 7 affected subpaths (., ./components, ./config, ./types, ./build, ./blend, ./testing). Same targets — pure condition-order correctness; no target/value change, no new/removed conditions, no `"type":"module"`. `./jest-preset` (no types) untouched.

Consistent with the Module-Resolution Contract (Spec 118): exports are Class A package-own compiled dist/ targets; this reorder doesn't touch the scoped TS loader, CJS-consistency direction, or resolution targets.

Verified: building against the types-first package.json drops the esbuild warning count 20 → 0. (Local worktree builds read the parent repo's package.json via ../../../ due to the nested-worktree layout, so this was proven against the file esbuild actually resolves; CI's Consumer Guard runs a clean checkout and will confirm 0 warnings on a full build.)