### PR TITLE
Extend delegate-then-verify to placement + delegated-edit always-cue

### DIFF
--- a/.kiro/specs/122-agent-generator/inbound-from-worktree-delegation-hazard.md
+++ b/.kiro/specs/122-agent-generator/inbound-from-worktree-delegation-hazard.md
@@ -43,3 +43,17 @@ Durable fix is upstream: place worktrees as **siblings** (outside the repo), not
 nested — then nothing above a worktree is another repo and all three symptoms vanish.
 That's a Claude Code harness behavior (feedback request to Anthropic). 122 mitigates
 via guidance; it does not own the root cause.
+
+---
+
+## Disposition (2026-07-09, Peter-approved — split into content-now / generation-in-122)
+
+The ask splits into two separable pieces; only the generation half is 122 scope, and it needs **no 122 artifact amendment** — it rides the existing always-set carry mechanism (see below). **No 122 re-ratification.**
+
+**Piece 1 — cue content AUTHORED NOW (done, outside the 122 build).** The placement-verify rule now exists as canonical always-layer content, so sessions are protected immediately (via the interim CLAUDE.md always-layer) rather than only when the build reaches its ambient tasks:
+- **Full rule + CC symptom** → `governance/Process-Orchestration-Model-Selection.md` § "The real guardrail: delegate-then-verify" — extends delegate-then-verify from *content* to *content AND placement*; carries the CC nested-worktree symptom and the sibling-worktrees root-cause pointer.
+- **Always-loaded touchpoint** → `.kiro/steering/start-up-tasks.md` item 6 (sibling to the model-tier cue) — terse "verify placement, not just content; hand over absolute paths; confirm the edit landed." Because `start-up-tasks.md` is (per the ratified design) an always-set member, 122 will carry this cue **for free**, the same path it carries the tiering cue.
+
+**Piece 2 — per-harness generation DEFERRED to 122's ambient / OB-7 cutover tasks.** No design change requested. When those tasks execute, resolve one **open design-fit question**: does the ratified five-class ambient design express *"symptom text emitted in the CC generation only, omitted from Kiro"* cleanly (harness-differentiated cue), or does the cue simply ride inside the always-set doc as-is (harmless, but the CC symptom text also reaches Kiro)? If harness-differentiation is wanted and not already expressible, that is a small design note for Thurgood at that point — **not** a re-ratification trigger. Flagged here so the ambient-task executor picks it up.
+
+**Must-carry (unchanged, now satisfiable):** the cue content now EXISTS to be carried; U10 (OB-7 CLAUDE.md retirement) must carry it into the superseding always-layer alongside the tiering cue. Add to U10's must-carry checklist.

--- a/.kiro/steering/start-up-tasks.md
+++ b/.kiro/steering/start-up-tasks.md
@@ -8,7 +8,7 @@ description: Essential pre-task checklist — date verification, governance heal
 # Start Up Tasks
 
 **Date**: 2025-10-20
-**Last Reviewed**: 2026-07-03
+**Last Reviewed**: 2026-07-09
 **Purpose**: Essential pre-task checklist for every task (date check, governance health, Jest commands, test selection, authorization-to-start). End-of-task sequence: see Task Completion Protocol.
 **Organization**: process-standard
 **Scope**: cross-project
@@ -114,6 +114,7 @@ description: Essential pre-task checklist — date verification, governance heal
    - **Deciding** — architecture, consequential/hard-to-reverse calls, cross-cutting tradeoffs, multiple failure modes → the higher tier (currently **Opus**). An escalation on a concrete signal, not a default-when-unsure.
    - Calibrate in BOTH directions relative to the session model: **downgrade** for implementation, **upgrade** for a decide task. Omitting the tier inherits the session's — a silent default, so decide it consciously.
    - **Always independently verify subagent output** before trusting it — delegate-then-verify is the guardrail, not the tier.
+   - **Verify placement, not just content**, when you delegate a **file edit**: hand the subagent **absolute paths** to the intended tree, and after it reports done **confirm the edit landed there** (a subagent can act on a different working tree and still report success — in Claude Code, nested worktrees let its relative paths resolve into the parent repo).
    
    Full policy + per-harness field mechanics: query `process-orchestration-model-selection` via the docs MCP.
 

--- a/governance/Process-Orchestration-Model-Selection.md
+++ b/governance/Process-Orchestration-Model-Selection.md
@@ -8,8 +8,8 @@ description: How an orchestrating agent picks a model tier for delegated subagen
 # Orchestration Model Selection
 
 **Date**: 2026-07-07
-**Last Reviewed**: 2026-07-07
-**Purpose**: How an orchestrating agent chooses the model tier for delegated subagent work, and why verification — not the tier — is the guardrail
+**Last Reviewed**: 2026-07-09
+**Purpose**: How an orchestrating agent chooses the model tier for delegated subagent work, and why verification — not the tier — is the guardrail (content AND placement)
 **Organization**: process-standard
 **Scope**: cross-project
 **Layer**: 2
@@ -48,6 +48,10 @@ Inherit is the right default because it **fails expensive, not wrong**: forgetti
 ## The real guardrail: delegate-then-verify
 
 **The safety mechanism is independent verification by the main loop, NOT the model tier.** Every subagent's output is re-checked before it is trusted: re-run the relevant tests and type-check, read the actual diff, spot-check against the contract. That review layer is what catches problems — including from capable tiers (a subagent once wrote a contrast *ratio* into a field expecting a color *value*; the main-loop review caught it, not the tier). The rule holds regardless of which tier ran the work: a higher tier is never a substitute for verifying; a cheaper tier under verification is safe *because* it is verified.
+
+**Verification covers placement, not just content.** When you delegate a **file edit**, the check is two-part: the content is correct AND the edit landed **where you intended** — in the intended working tree, on the intended branch. A subagent can silently act on a *different* working tree than you meant and report success anyway, because relative paths resolve from *its* working directory, not yours. Defend against it on both ends: **hand the subagent absolute paths to the intended tree** when you delegate, and **after it reports done, confirm the change is where you expect** (`git status`/`git diff` in the intended tree, or read the file at its absolute path) before you trust or commit it. This extends the content-verification rule above to *placement*; a "done" report is a claim about content, never a guarantee about location.
+
+- **Claude Code symptom (harness-specific).** CC nests worktrees *inside* the repo (`.claude/worktrees/<name>/`), so upward path or module resolution from a subagent (`../../../`) can cross the worktree boundary into the **parent repo** — a delegated edit lands on the parent-repo copy instead of the worktree branch, esbuild reads the parent's `package.json`, etc. Observed 3× in one session. The placement check above is the mitigation; the durable fix is upstream (place worktrees as *siblings* of the repo, not nested — a Claude Code harness-behavior request), which this guardrail does not own. Other harnesses carry this symptom note only if they reproduce the nesting condition.
 
 ## Escalation, not default-when-unsure
 


### PR DESCRIPTION
**Spec:** 122-agent-generator (inbound disposition — governance content authored outside the build)
**Task:** Piece 1 of the worktree-delegation-hazard inbound — author the placement-verify cue now
**Agent:** main-loop (Opus), main-loop-verified
**Validation:** steering-metadata validator 0 errors; docs MCP index rebuilt healthy (82 docs).

## What this does
Resolves the **content half** of the 122 worktree-delegation-hazard inbound (Peter-approved 2026-07-09) — authored now, outside the 122 build, so sessions are protected immediately rather than only when the build reaches its ambient tasks.

- **`Process-Orchestration-Model-Selection.md` § "The real guardrail: delegate-then-verify"** — extends the guardrail from *content* to *content AND placement*: when you delegate a file edit, hand the subagent absolute paths and confirm the edit landed in the intended tree, because a subagent can act on a different working tree and still report success. Carries the CC-specific symptom (nested worktrees → `../../../` crosses into the parent repo; observed 3× in one session) and the upstream root-cause pointer (sibling worktrees — a harness request, not 122-owned).
- **`start-up-tasks.md` item 6** — terse always-loaded touchpoint (sibling to the model-tier cue). Because start-up-tasks is an always-set member, 122 carries this cue for free, same path as the tiering cue.
- **inbound doc** — records the disposition: Piece 2 (per-harness generation + CC-only symptom differentiation) deferred to 122's ambient/OB-7 tasks with one open design-fit question; **no 122 amendment / no re-ratification**; must-carry into U10's checklist.

## Classification (your call)
This is a **refinement of the existing, ratified delegate-then-verify guardrail** (content → placement), not new completion/merge/authority law. I routed it through the PR gate (governance carve-out — your merge is the acceptance) rather than a full record-first ballot. If you classify it as law-level, bounce it and I'll run the ballot route instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)