### PR TITLE
Guard mcp-server entry: no server start on library import

### DIFF
--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -417,11 +417,19 @@ async function main(): Promise<void> {
   await server.start();
 }
 
-// Run the server
-main().catch((error) => {
-  console.error('[MCP Server] Fatal error:', error);
-  process.exit(1);
-});
+// Run the server ONLY when this module is the process entry point (executed
+// directly — `node mcp-server/dist/index.js`, or the esbuild `dist/mcp/docs-mcp.js`
+// bundle a consumer launches). Importing this module as a LIBRARY (Spec 122 imports
+// the re-exported WORKFLOW_RULES from the package entry) must NOT start the server;
+// the previous unconditional call started an MCP server as an import side effect.
+// This module is CommonJS (tsconfig `module: commonjs`), so `require.main === module`
+// is the correct entry check — verified to still fire under the esbuild CJS bundle.
+if (require.main === module) {
+  main().catch((error) => {
+    console.error('[MCP Server] Fatal error:', error);
+    process.exit(1);
+  });
+}
 
 // Export for testing
 export { MCPDocumentationServer };


### PR DESCRIPTION
**Spec:** none (tooling fix; unblocks a Spec 122 import)
**Task:** Stop `mcp-server/src/index.ts` from starting the MCP server as a side effect of importing the package entry
**Agent:** main-loop (Opus), main-loop-verified
**Validation:** mcp-server suite 600/600; typecheck clean; behavioral verification below.

## Problem
The docs-MCP entry re-exports library values (`WORKFLOW_RULES` et al., Spec 121 Task 6) but also called `main()` unconditionally at module top level. So importing the entry as a library **started an MCP server as a side effect**. Spec 122 Task 1.3 hit this and had to import from a submodule (`mcp-server/dist/rules/workflow-rules`) to avoid it.

## Fix
Wrap the `main()` call in `if (require.main === module)`. The module is CommonJS (`tsconfig module: commonjs`), so `require.main === module` is the correct entry check.

## Verification (both compiled forms the server actually ships as)
Per the mcp-runs-from-compiled-output constraint, I verified the *built* artifacts, not just source:

| Artifact | `require()` (import) | `node <file>` (run) |
|---|---|---|
| tsc `mcp-server/dist/index.js` (in-repo `.mcp.json` launch) | exports only, **no server start** ✅ | server starts ✅ |
| esbuild `dist/mcp/docs-mcp.js` (consumer launch; the require.main-in-bundle risk) | exports only, **no server start** ✅ | server starts ✅ |

- No consumer relied on the old auto-start (the only `WORKFLOW_RULES` test imports the `rules/` submodule, not the entry).
- `relocation-integrity-gate` reads `index.ts` only to check `DEFAULT_STEERING_DIR` — untouched.

Spec 122 can now import `WORKFLOW_RULES` from the package entry cleanly (a follow-up, not required here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)