### PR TITLE
Guard mcp-server entry: don't start the server on library import

### DIFF
--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -417,11 +417,19 @@ async function main(): Promise<void> {
   await server.start();
 }
 
-// Run the server
-main().catch((error) => {
-  console.error('[MCP Server] Fatal error:', error);
-  process.exit(1);
-});
+// Run the server ONLY when this module is the process entry point (executed
+// directly — `node mcp-server/dist/index.js`, or the esbuild `dist/mcp/docs-mcp.js`
+// bundle a consumer launches). Importing this module as a LIBRARY (Spec 122 imports
+// the re-exported WORKFLOW_RULES from the package entry) must NOT start the server;
+// the previous unconditional call started an MCP server as an import side effect.
+// This module is CommonJS (tsconfig `module: commonjs`), so `require.main === module`
+// is the correct entry check — verified to still fire under the esbuild CJS bundle.
+if (require.main === module) {
+  main().catch((error) => {
+    console.error('[MCP Server] Fatal error:', error);
+    process.exit(1);
+  });
+}
 
 // Export for testing
 export { MCPDocumentationServer };


### PR DESCRIPTION
**Spec:** none (standalone fix; unblocks Spec 122 Task 1.3 / design C2.4)
**Agent:** Peter (human-authored commit `5d2a779a`; co-authored Opus 4.8)
**Validation:** mcp-server suite 600/600 green + typecheck clean (per commit record), verified in both compiled forms (tsc `dist/index.js` and the esbuild consumer bundle).

## What
Wrap the top-level `main()` call in `mcp-server/src/index.ts` in `if (require.main === module)` so the MCP server starts only when the module is the process entry point — not as a side effect of importing the package entry as a library.

## Why
`mcp-server/src/index.ts` re-exports library values (`WORKFLOW_RULES` et al., Spec 121 Task 6) but also called `main()` unconditionally at module top level, so `import { WORKFLOW_RULES }` from the package entry booted an MCP server. Spec 122 Task 1.3 hit this and had to work around it by importing the compiled submodule (`mcp-server/dist/rules/workflow-rules`) instead of the design-specified package entry.

This fix lets 122 import `WORKFLOW_RULES` from the package entry cleanly (design C2.4). Follow-up after merge: rebase `task/122-substrate` on `main` and flip Task 1.3's import from the submodule workaround to the package entry.

## Scope
One file, +13/−5. CommonJS module (`tsconfig module: commonjs`), so `require.main === module` is the correct entry check — verified to still fire under the esbuild CJS bundle. No consumer relied on the old auto-start.

🤖 Generated with [Claude Code](https://claude.com/claude-code)