### PR TITLE
125-A Task 6: lane-timing measurement workflow (5 non-required lanes)

### DIFF
--- a/.github/workflows/lane-timing.yml
+++ b/.github/workflows/lane-timing.yml
@@ -70,6 +70,15 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      # Fresh-checkout prerequisite (lane-timing run #1 finding): src/types/generated/** is
+      # GITIGNORED generated source (scripts/generate-token-types.ts emits TokenTypes.ts;
+      # package.json's `prebuild` runs it). It exists on dev machines but never on a clean
+      # CI checkout, so the full typecheck fails with TS2307 without this step. Its cost is
+      # deliberately part of this lane's measured wall-clock — it is the honest fresh-checkout
+      # cost of typechecking this repo.
+      - name: Generate token types (gitignored generated source)
+        run: npm run generate:types
+
       - name: Typecheck (full, no skipLibCheck)
         run: npx tsc --noEmit
 
@@ -133,6 +142,18 @@ jobs:
 
       - name: Install dependencies
         run: npm ci
+
+      # Fresh-checkout prerequisite (lane-timing run #1 finding): the root functional suite
+      # is NOT self-contained on a clean tree — the export-contract tests (Spec 106 R7)
+      # require() the BUILT package per the package.json exports map (dist/testing,
+      # dist/browser/designerpunk.esm.js, dist/config, ...), and src/types imports the
+      # gitignored generated TokenTypes. `npm run build` covers both: its `prebuild` runs
+      # generate:types + generate:platform-tokens, then tsc + build:validate + build:browser
+      # + build:mcp. The build is deliberately part of this lane's measured wall-clock —
+      # that IS the honest fresh-checkout cost of running the root suite as a future
+      # required check (and exactly the hidden-prerequisite class Task 6 exists to surface).
+      - name: Build (prebuild generates + tsc + bundles — required by export-contract tests)
+        run: npm run build
 
       - name: Run functional test suite
         run: npm test
@@ -205,12 +226,15 @@ jobs:
           node-version: '22'
 
       # Prerequisite investigation (Task 6): application-mcp-server/jest.config.js
-      # uses the same `preset: 'ts-jest'` + `roots: ['<rootDir>/src', '<rootDir>/tests']`
-      # pattern as mcp-server (plus moduleNameMapper stubs for the ESM-only
-      # @modelcontextprotocol/sdk so ts-jest/CJS can load it) — tests run directly
-      # against TypeScript source, no dist/ build required. package.json's "test"
-      # script is plain `jest` (no pretest/build step). No root `npm ci` is needed:
-      # this sub-package's own package-lock.json supplies everything its tests use.
+      # uses `preset: 'ts-jest'` with src-only roots (plus moduleNameMapper stubs for
+      # the ESM-only @modelcontextprotocol/sdk so ts-jest/CJS can load it) — tests run
+      # directly against TypeScript source, no dist/ build required. package.json's
+      # "test" script is plain `jest` (no pretest/build step). No root `npm ci` is
+      # needed: this sub-package's own package-lock.json supplies everything its tests
+      # use. Run #1 finding: the config previously declared a '<rootDir>/tests' root
+      # pointing at an EMPTY, untracked dir — present on dev machines, absent on a
+      # fresh CI checkout (git tracks no empty dirs), so jest failed with "roots[1]
+      # not found". Fixed in application-mcp-server/jest.config.js (roots now src-only).
       - name: Install dependencies (application-mcp-server)
         run: npm ci
 

--- a/.github/workflows/lane-timing.yml
+++ b/.github/workflows/lane-timing.yml
@@ -1,0 +1,218 @@
+# Spec 125-A Task 6 — CI Lane Timing Measurement
+#
+# PURPOSE: measure cold-cache and cached steady-state wall-clock for five CI-lane
+# candidates. These jobs are deliberately NON-REQUIRED — they are omitted from
+# the branch-protection required-checks list (Settings → Branches → main →
+# Require status checks). They run on every PR (accumulating cached steady-state
+# samples for free) and can additionally be dispatched manually with `cold: true`
+# to force a cache-miss run.
+#
+# MEASUREMENT READOUT: GitHub Actions' native per-job duration display (the
+# "Summary" page for a run, and each job's page) IS the measurement instrument
+# for this task — no custom timing/reporting code is added here. Record both:
+#   - Cached steady-state: the normal `pull_request`-triggered duration once the
+#     npm cache is warm (i.e. after at least one successful run has populated it).
+#   - Cold-cache: the `workflow_dispatch` run with `cold: true`, which skips the
+#     npm cache restore step so `npm ci` (and npm-cache-dependent installs) pay
+#     full network/extraction cost.
+# Req 6.3 wants BOTH numbers recorded for each lane.
+#
+# PAUSE-FOR-PETER THRESHOLD: if any lane's COLD-CACHE duration approaches or
+# exceeds ~10 minutes (125-A Req 6.3's ceiling), stop and flag it to Peter before
+# proceeding to Task 7 (selection-floor + scope guards) or Task 8 (promotion to
+# required). A lane that blows the ceiling needs scope/parallelization rework,
+# not a silent promotion.
+#
+# LIFECYCLE: Task 7 adds selection-floor + scope guards to these same jobs.
+# Task 8 promotes some/all of them into the branch-protection required-checks
+# list. Job ids/names below are chosen to be durable across both later tasks —
+# do not rename without updating the (future) required-checks configuration.
+#
+# @see .kiro/specs/125-A-pr-gate-mechanical-arming/requirements.md (Req 6.3)
+# @see .github/workflows/consumer-guard.yml (prior-art conventions this file follows)
+
+name: Lane Timing
+
+on:
+  pull_request:
+  workflow_dispatch:
+    inputs:
+      cold:
+        description: 'Force cold-cache measurement (skip npm cache restore)'
+        type: boolean
+        default: false
+
+jobs:
+  # ── Lane 1: root typecheck ────────────────────────────────────────────────
+  lane-typecheck:
+    name: lane-typecheck
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      # Two setup-node steps guarded by `if:` — `cache:` cannot be conditionally
+      # disabled inline, so cold-cache dispatch runs use the cache-free variant.
+      - name: Setup Node.js (cached)
+        if: ${{ github.event.inputs.cold != 'true' }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - name: Setup Node.js (cold, no cache)
+        if: ${{ github.event.inputs.cold == 'true' }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Typecheck (full, no skipLibCheck)
+        run: npx tsc --noEmit
+
+  # ── Lane 2: build:validate ──────────────────────────────────────────────
+  lane-build-validate:
+    name: lane-build-validate
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js (cached)
+        if: ${{ github.event.inputs.cold != 'true' }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - name: Setup Node.js (cold, no cache)
+        if: ${{ github.event.inputs.cold == 'true' }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Install dependencies
+        run: npm ci
+
+      # Prerequisite investigation (Task 6): src/validators/buildValidation.ts
+      # validates accessibility tokens by importing in-repo TS modules directly
+      # (ThreeTierValidator, WCAGValidator, SpacingTokens, BorderWidthTokens,
+      # semantic ColorTokens) — it does NOT read dist/ build output. `build:validate`
+      # (= `npx tsx src/validators/buildValidation.ts`) runs it via tsx's on-the-fly
+      # TS transpilation, so no prior `tsc`/`build:browser`/`build:mcp` step is
+      # required for this script to execute correctly. No prerequisite build step
+      # is included in this job's measured wall-clock as a result.
+      - name: Build validation (accessibility token validation)
+        run: npm run build:validate
+
+  # ── Lane 3: root functional test suite ──────────────────────────────────
+  lane-functional-root:
+    name: lane-functional-root
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js (cached)
+        if: ${{ github.event.inputs.cold != 'true' }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - name: Setup Node.js (cold, no cache)
+        if: ${{ github.event.inputs.cold == 'true' }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run functional test suite
+        run: npm test
+
+  # ── Lane 4: mcp-server suite ─────────────────────────────────────────────
+  lane-mcp-server-suite:
+    name: lane-mcp-server-suite
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    defaults:
+      run:
+        working-directory: mcp-server
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js (cached)
+        if: ${{ github.event.inputs.cold != 'true' }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+          cache-dependency-path: mcp-server/package-lock.json
+
+      - name: Setup Node.js (cold, no cache)
+        if: ${{ github.event.inputs.cold == 'true' }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      # Prerequisite investigation (Task 6): mcp-server/jest.config.js uses
+      # `preset: 'ts-jest'` with `roots: ['<rootDir>/src', '<rootDir>/tests']` —
+      # tests run directly against TypeScript source via ts-jest's on-the-fly
+      # transpilation. mcp-server/package.json's "test" script is plain `jest`
+      # (no pretest/build step). Cross-checked tests/integration/*.test.ts and
+      # tests/performance/performance.test.ts import via `../../src/...`, which
+      # resolves to mcp-server/src (package-relative), not the repo root — this
+      # sub-package's tests do not reach root node_modules or root src. No `dist/`
+      # build and no root `npm ci` are required for this job.
+      - name: Install dependencies (mcp-server)
+        run: npm ci
+
+      - name: Run mcp-server test suite
+        run: npm test
+
+  # ── Lane 5: application-mcp-server suite ─────────────────────────────────
+  lane-application-mcp-server-suite:
+    name: lane-application-mcp-server-suite
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    defaults:
+      run:
+        working-directory: application-mcp-server
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js (cached)
+        if: ${{ github.event.inputs.cold != 'true' }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+          cache-dependency-path: application-mcp-server/package-lock.json
+
+      - name: Setup Node.js (cold, no cache)
+        if: ${{ github.event.inputs.cold == 'true' }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      # Prerequisite investigation (Task 6): application-mcp-server/jest.config.js
+      # uses the same `preset: 'ts-jest'` + `roots: ['<rootDir>/src', '<rootDir>/tests']`
+      # pattern as mcp-server (plus moduleNameMapper stubs for the ESM-only
+      # @modelcontextprotocol/sdk so ts-jest/CJS can load it) — tests run directly
+      # against TypeScript source, no dist/ build required. package.json's "test"
+      # script is plain `jest` (no pretest/build step). No root `npm ci` is needed:
+      # this sub-package's own package-lock.json supplies everything its tests use.
+      - name: Install dependencies (application-mcp-server)
+        run: npm ci
+
+      - name: Run application-mcp-server test suite
+        run: npm test

--- a/.github/workflows/lane-timing.yml
+++ b/.github/workflows/lane-timing.yml
@@ -155,6 +155,14 @@ jobs:
       - name: Build (prebuild generates + tsc + bundles — required by export-contract tests)
         run: npm run build
 
+      # Run #2 finding: two suites (mcp-queryability, mcp-component-integration) assert the
+      # mcp-server SUB-PACKAGE is built (`fs.existsSync(mcp-server/dist/index.js)`), which
+      # the root `npm run build` does not produce (build:mcp emits the esbuild bundles to
+      # the root dist/mcp/, not the sub-package's own tsc dist/). Build it here — also
+      # deliberately part of the measured wall-clock.
+      - name: Build mcp-server sub-package (asserted by mcp-queryability tests)
+        run: npm ci --prefix mcp-server && npm run build --prefix mcp-server
+
       - name: Run functional test suite
         run: npm test
 

--- a/application-mcp-server/jest.config.js
+++ b/application-mcp-server/jest.config.js
@@ -1,8 +1,13 @@
 module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'node',
-  roots: ['<rootDir>/src', '<rootDir>/tests'],
-  testMatch: ['**/__tests__/**/*.test.ts', '**/tests/**/*.test.ts'],
+  // roots deliberately src-only: every test in this package lives under src/**/__tests__/.
+  // A '<rootDir>/tests' root previously listed here pointed at an EMPTY, untracked directory —
+  // it existed on local machines (so jest tolerated it) but not on a fresh CI checkout (git
+  // does not track empty dirs), making `npm test` fail with "Directory ... in the roots[1]
+  // option was not found" the first time the suite ran in CI (125-A Task 6, lane-timing run #1).
+  roots: ['<rootDir>/src'],
+  testMatch: ['**/__tests__/**/*.test.ts'],
   collectCoverageFrom: [
     'src/**/*.ts',
     '!src/**/*.d.ts',

--- a/src/build/workflow/__tests__/CICDIntegration.test.ts
+++ b/src/build/workflow/__tests__/CICDIntegration.test.ts
@@ -490,9 +490,20 @@ describe('CICDIntegration', () => {
   
   describe('Environment Detection', () => {
     const originalEnv = process.env;
-    
+
     beforeEach(() => {
       process.env = { ...originalEnv };
+      // Neutralize the HOST's own CI environment before each scenario. On a real CI
+      // runner (e.g. GitHub Actions) the ambient GITHUB_ACTIONS/CI vars leak into the
+      // copied env and win detectCICDEnvironment()'s precedence order, so the GitLab
+      // and generic-CI scenarios detected 'github' instead — these tests only ever
+      // passed on laptops because laptops aren't CI (125-A Task 6, lane-timing run #2
+      // finding). Each scenario sets exactly the vars it means to test.
+      delete process.env.GITHUB_ACTIONS;
+      delete process.env.GITHUB_WORKFLOW;
+      delete process.env.GITLAB_CI;
+      delete process.env.CI_PIPELINE_ID;
+      delete process.env.CI;
     });
     
     afterEach(() => {


### PR DESCRIPTION
**Spec:** 125-A-pr-gate-mechanical-arming
**Task:** 6 — Measure cold-cache CI timing for the candidate lanes (draft; measurements read AFTER merge once runs accumulate)
**Agent:** Main loop (Fable 5) + 1 Sonnet subagent, main-loop verified
**Validation:** YAML parse OK (js-yaml); if-logic verified for both trigger paths; jobs are NON-required by omission from the protection list — this PR changes no gate behavior.

## What

The five candidate lanes as parallel, non-required jobs: `lane-typecheck`, `lane-build-validate`, `lane-functional-root`, `lane-mcp-server-suite`, `lane-application-mcp-server-suite`. Runs on every PR (steady-state samples for free) + `workflow_dispatch` with a `cold: true` input that skips the npm cache restore for cold-cache measurement.

Prerequisite questions were investigated with file evidence, not guessed (recorded as YAML comments): `build:validate` needs no build (tsx transpiles TS source directly); both sub-package suites run ts-jest against src with self-sufficient lockfiles.

## Notes for the merge

- **This PR's own run is the first timing sample** — the five job durations on this PR's checks tab are cold-ish (first cache population).
- **If merged 2026-07-10 or later, this merge is the 5th qualifying bake-in day** (Task 5's day-count criterion closes).
- After merge: dispatch one `cold: true` run for clean cold numbers → record both forms per lane in the Task 6 completion doc → pause for Peter only if any cold lane approaches ~10 min.
- Task 7 hardens these same jobs (selection floors + scope guards); Task 8 promotes them to required. Job names are durable for that path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)