### PR TITLE
Silence intentional test console noise: 96 error + 72 warn blocks → 0

### DIFF
--- a/product-mcp-server/src/__tests__/GapDetector.test.ts
+++ b/product-mcp-server/src/__tests__/GapDetector.test.ts
@@ -48,13 +48,22 @@ describe('GapDetector', () => {
   });
 
   describe('with missing component directory', () => {
+    beforeEach(() => {
+      // GapDetector logs "gap detection disabled" via console.error when the dir is missing;
+      // only the first test below asserts on it — silence it for the others.
+      jest.spyOn(console, 'error').mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+      jest.restoreAllMocks();
+    });
+
     it('logs warning and leaves catalog empty', () => {
       const spy = jest.spyOn(console, 'error').mockImplementation();
       const detector = new GapDetector('/nonexistent/path', new Set());
       detector.loadCatalog();
       expect(detector.getCatalogSize()).toBe(0);
       expect(spy).toHaveBeenCalledWith(expect.stringContaining('gap detection disabled'));
-      spy.mockRestore();
     });
 
     it('returns not-found for all components when catalog is empty', () => {

--- a/product-mcp-server/src/__tests__/ProductIndexerWalk.test.ts
+++ b/product-mcp-server/src/__tests__/ProductIndexerWalk.test.ts
@@ -12,10 +12,17 @@ const MOCK_COMPONENTS = path.join(FIXTURE_DIR, 'mock-components');
 
 describe('ProductIndexer walk integration', () => {
   let indexer: ProductIndexer;
+  let consoleErrorSpy: jest.SpyInstance;
 
   beforeAll(async () => {
+    // ProductIndexer.index() logs an indexing summary via console.error (informational, not a failure)
+    consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
     indexer = new ProductIndexer(FIXTURE_DIR, MOCK_COMPONENTS);
     await indexer.index();
+  });
+
+  afterAll(() => {
+    consoleErrorSpy.mockRestore();
   });
 
   describe('reverse indexes — components', () => {

--- a/product-mcp-server/src/__tests__/Spec108-ProductTokens.test.ts
+++ b/product-mcp-server/src/__tests__/Spec108-ProductTokens.test.ts
@@ -13,10 +13,17 @@ const TOKEN_INDEX = path.join(__dirname, 'fixtures', 'token-index');
 
 describe('Spec 108: Product Tokens Integration', () => {
   let indexer: ProductIndexer;
+  let consoleErrorSpy: jest.SpyInstance;
 
   beforeAll(async () => {
+    // ProductIndexer.index() logs an indexing summary via console.error (informational, not a failure)
+    consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
     indexer = new ProductIndexer(FIXTURE_DIR, MOCK_COMPONENTS, TOKEN_INDEX);
     await indexer.index();
+  });
+
+  afterAll(() => {
+    consoleErrorSpy.mockRestore();
   });
 
   describe('get_product_tokens response shape', () => {

--- a/src/__tests__/integration/Spec107-DesignLanguageContext.test.ts
+++ b/src/__tests__/integration/Spec107-DesignLanguageContext.test.ts
@@ -16,6 +16,22 @@ const PHILOSOPHY_PATH = path.resolve(__dirname, '../../../design-language/design
 const PRODUCT_FIXTURES = path.resolve(__dirname, '../../../product-mcp-server/src/__tests__/fixtures');
 
 describe('Spec 107 Integration: Design Language Context', () => {
+  let consoleErrorSpy: jest.SpyInstance;
+
+  beforeAll(() => {
+    // ProductIndexer logs indexing summaries via console.error (informational, not a failure).
+    // Installed in beforeAll (not beforeEach) so it's active before nested beforeAll hooks
+    // that construct/index a ProductIndexer run.
+    consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterAll(() => {
+    consoleErrorSpy.mockRestore();
+  });
+
+  beforeEach(() => {
+    consoleErrorSpy.mockClear();
+  });
 
   describe('Application MCP — Design Philosophy', () => {
     let indexer: any;

--- a/src/build/errors/__tests__/ErrorHandler.integration.test.ts
+++ b/src/build/errors/__tests__/ErrorHandler.integration.test.ts
@@ -13,6 +13,14 @@ import { createBuildError } from '../BuildError';
 import { BuildResultSummary } from '../ErrorReporter';
 
 describe('ErrorHandler - ErrorReporter Integration', () => {
+  beforeEach(() => {
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
   describe('generateReport', () => {
     it('should generate report from logged errors', () => {
       const handler = new ErrorHandler();

--- a/src/build/errors/__tests__/ErrorHandler.test.ts
+++ b/src/build/errors/__tests__/ErrorHandler.test.ts
@@ -13,7 +13,12 @@ describe('ErrorHandler', () => {
   let errorHandler: ErrorHandler;
 
   beforeEach(() => {
+    jest.spyOn(console, 'error').mockImplementation(() => {});
     errorHandler = new ErrorHandler();
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
   });
 
   describe('constructor', () => {

--- a/src/components/core/Avatar-Base/__tests__/Avatar.accessibility.test.ts
+++ b/src/components/core/Avatar-Base/__tests__/Avatar.accessibility.test.ts
@@ -33,11 +33,14 @@ describe('Avatar Component Accessibility', () => {
   beforeEach(async () => {
     // Wait for custom element to be defined
     await customElements.whenDefined('avatar-base');
+    // Suppress expected "alt required with src" warning for tests that don't assert on it
+    jest.spyOn(console, 'warn').mockImplementation(() => {});
   });
 
   afterEach(() => {
     // Clean up any created elements
     cleanupDOM();
+    jest.restoreAllMocks();
   });
 
   // ============================================================================

--- a/src/components/core/Avatar-Base/__tests__/Avatar.accessibility.test.ts
+++ b/src/components/core/Avatar-Base/__tests__/Avatar.accessibility.test.ts
@@ -33,14 +33,11 @@ describe('Avatar Component Accessibility', () => {
   beforeEach(async () => {
     // Wait for custom element to be defined
     await customElements.whenDefined('avatar-base');
-    // Suppress expected "alt required with src" warning for tests that don't assert on it
-    jest.spyOn(console, 'warn').mockImplementation(() => {});
   });
 
   afterEach(() => {
     // Clean up any created elements
     cleanupDOM();
-    jest.restoreAllMocks();
   });
 
   // ============================================================================
@@ -215,17 +212,24 @@ describe('Avatar Component Accessibility', () => {
     });
 
     it('should apply empty alt when alt is empty string', async () => {
+      // This fixture DELIBERATELY uses alt='' (the decorative-image pattern this test
+      // asserts). The component's Req 5.4 check is `src && !alt`, which treats '' as
+      // missing and warns — a known tension between Req 5.4 and the decorative pattern
+      // (Req 9.2), flagged for Lina to adjudicate at the component level. Locally
+      // silence the expected warn; do NOT change the fixture (it IS the test).
+      const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
       const avatar = document.createElement('avatar-base') as AvatarBaseElement;
       avatar.type = 'human';
       avatar.src = 'https://example.com/profile.jpg';
       avatar.alt = '';
       document.body.appendChild(avatar);
-      
+
       await new Promise(resolve => setTimeout(resolve, 0));
-      
+
       const img = avatar.shadowRoot?.querySelector('.avatar__image');
       expect(img).toBeTruthy();
       expect(img?.getAttribute('alt')).toBe('');
+      warnSpy.mockRestore();
     });
 
     it('should update alt when alt attribute changes', async () => {

--- a/src/components/core/Avatar-Base/__tests__/Avatar.image.test.ts
+++ b/src/components/core/Avatar-Base/__tests__/Avatar.image.test.ts
@@ -33,11 +33,14 @@ describe('Avatar Component Image Handling', () => {
   beforeEach(async () => {
     // Wait for custom element to be defined
     await customElements.whenDefined('avatar-base');
+    // Suppress expected "alt required with src" warning for tests that don't assert on it
+    jest.spyOn(console, 'warn').mockImplementation(() => {});
   });
 
   afterEach(() => {
     // Clean up any created elements
     cleanupDOM();
+    jest.restoreAllMocks();
   });
 
   // ============================================================================

--- a/src/components/core/Avatar-Base/__tests__/Avatar.image.test.ts
+++ b/src/components/core/Avatar-Base/__tests__/Avatar.image.test.ts
@@ -33,14 +33,11 @@ describe('Avatar Component Image Handling', () => {
   beforeEach(async () => {
     // Wait for custom element to be defined
     await customElements.whenDefined('avatar-base');
-    // Suppress expected "alt required with src" warning for tests that don't assert on it
-    jest.spyOn(console, 'warn').mockImplementation(() => {});
   });
 
   afterEach(() => {
     // Clean up any created elements
     cleanupDOM();
-    jest.restoreAllMocks();
   });
 
   // ============================================================================
@@ -290,6 +287,7 @@ describe('Avatar Component Image Handling', () => {
       const avatar = document.createElement('avatar-base') as AvatarBaseElement;
       avatar.type = 'agent';
       avatar.src = 'https://example.com/agent-image.jpg';
+      avatar.alt = 'Agent profile'; // honor the alt-with-src contract (Req 5.4)
       document.body.appendChild(avatar);
       
       await new Promise(resolve => setTimeout(resolve, 0));
@@ -302,6 +300,7 @@ describe('Avatar Component Image Handling', () => {
       const avatar = document.createElement('avatar-base') as AvatarBaseElement;
       avatar.type = 'agent';
       avatar.src = 'https://example.com/agent-image.jpg';
+      avatar.alt = 'Agent profile'; // honor the alt-with-src contract (Req 5.4)
       document.body.appendChild(avatar);
       
       await new Promise(resolve => setTimeout(resolve, 0));
@@ -314,6 +313,7 @@ describe('Avatar Component Image Handling', () => {
       const avatar = document.createElement('avatar-base') as AvatarBaseElement;
       avatar.type = 'agent';
       avatar.src = 'https://example.com/agent-image.jpg';
+      avatar.alt = 'Agent profile'; // honor the alt-with-src contract (Req 5.4)
       document.body.appendChild(avatar);
       
       await new Promise(resolve => setTimeout(resolve, 0));

--- a/src/components/core/Avatar-Base/__tests__/Avatar.test.ts
+++ b/src/components/core/Avatar-Base/__tests__/Avatar.test.ts
@@ -31,15 +31,9 @@ describe('Avatar Component Core API', () => {
     }
   });
 
-  beforeEach(() => {
-    // Suppress expected "alt required with src" warning for tests that don't assert on it
-    jest.spyOn(console, 'warn').mockImplementation(() => {});
-  });
-
   afterEach(() => {
     // Clean up any created elements
     cleanupDOM();
-    jest.restoreAllMocks();
   });
 
   // ============================================================================
@@ -224,27 +218,33 @@ describe('Avatar Component Core API', () => {
   // ============================================================================
   
   describe('Src Prop', () => {
+    // Fixtures set `alt` alongside `src` so they honor the component's own a11y
+    // contract (Req 5.4: alt is required with src) — otherwise the component
+    // rightly warns, polluting CI logs. The assertions below are about src only.
     it('should accept src value', () => {
       const avatar = document.createElement('avatar-base') as AvatarBaseElement;
       avatar.src = 'https://example.com/image.jpg';
+      avatar.alt = 'Test avatar';
       document.body.appendChild(avatar);
-      
+
       expect(avatar.src).toBe('https://example.com/image.jpg');
       expect(avatar.getAttribute('src')).toBe('https://example.com/image.jpg');
     });
 
     it('should update src via attribute', () => {
       const avatar = document.createElement('avatar-base') as AvatarBaseElement;
+      avatar.alt = 'Test avatar';
       document.body.appendChild(avatar);
-      
+
       avatar.setAttribute('src', 'https://example.com/new-image.jpg');
       expect(avatar.src).toBe('https://example.com/new-image.jpg');
     });
 
     it('should update src via property', () => {
       const avatar = document.createElement('avatar-base') as AvatarBaseElement;
+      avatar.alt = 'Test avatar';
       document.body.appendChild(avatar);
-      
+
       avatar.src = 'https://example.com/profile.png';
       expect(avatar.getAttribute('src')).toBe('https://example.com/profile.png');
     });
@@ -252,8 +252,9 @@ describe('Avatar Component Core API', () => {
     it('should remove src attribute when set to null', () => {
       const avatar = document.createElement('avatar-base') as AvatarBaseElement;
       avatar.src = 'https://example.com/image.jpg';
+      avatar.alt = 'Test avatar';
       document.body.appendChild(avatar);
-      
+
       avatar.src = null;
       expect(avatar.src).toBeNull();
       expect(avatar.hasAttribute('src')).toBe(false);
@@ -572,8 +573,9 @@ describe('Avatar Component Core API', () => {
 
     it('should reflect src property to attribute', () => {
       const avatar = document.createElement('avatar-base') as AvatarBaseElement;
+      avatar.alt = 'Test avatar'; // honor the alt-with-src contract (Req 5.4)
       document.body.appendChild(avatar);
-      
+
       avatar.src = 'https://example.com/test.jpg';
       expect(avatar.getAttribute('src')).toBe('https://example.com/test.jpg');
     });
@@ -635,8 +637,9 @@ describe('Avatar Component Core API', () => {
     it('should read src attribute as property', () => {
       const avatar = document.createElement('avatar-base') as AvatarBaseElement;
       avatar.setAttribute('src', 'https://example.com/img.png');
+      avatar.setAttribute('alt', 'Test avatar'); // honor the alt-with-src contract (Req 5.4)
       document.body.appendChild(avatar);
-      
+
       expect(avatar.src).toBe('https://example.com/img.png');
     });
 

--- a/src/components/core/Avatar-Base/__tests__/Avatar.test.ts
+++ b/src/components/core/Avatar-Base/__tests__/Avatar.test.ts
@@ -31,9 +31,15 @@ describe('Avatar Component Core API', () => {
     }
   });
 
+  beforeEach(() => {
+    // Suppress expected "alt required with src" warning for tests that don't assert on it
+    jest.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
   afterEach(() => {
     // Clean up any created elements
     cleanupDOM();
+    jest.restoreAllMocks();
   });
 
   // ============================================================================

--- a/src/components/core/Chip-Base/__tests__/ChipBase.test.ts
+++ b/src/components/core/Chip-Base/__tests__/ChipBase.test.ts
@@ -40,11 +40,14 @@ describe('Chip-Base Web Component', () => {
   beforeEach(async () => {
     // Wait for custom element to be defined
     await customElements.whenDefined('chip-base');
+    // Suppress expected blend-color warning (fires async via rAF; no real CSS in jsdom)
+    jest.spyOn(console, 'warn').mockImplementation(() => {});
   });
 
   afterEach(() => {
     // Clean up any created elements
     cleanupDOM();
+    jest.restoreAllMocks();
   });
 
   // ============================================================================

--- a/src/components/core/Chip-Base/__tests__/ChipBase.test.ts
+++ b/src/components/core/Chip-Base/__tests__/ChipBase.test.ts
@@ -46,7 +46,10 @@ describe('Chip-Base Web Component', () => {
     // Anything ELSE passes through to the real console — a NEW warn class stays audible.
     const realWarn = console.warn.bind(console);
     jest.spyOn(console, 'warn').mockImplementation((...args: unknown[]) => {
-      if (typeof args[0] === 'string' && args[0].includes('Could not calculate blend colors')) return;
+      // Component-prefixed match (Lina review, PR #39): the bare substring is shared by
+      // Button components too — prefix-matching prevents accidentally swallowing a
+      // cross-component warn if this suite ever composes a Button.
+      if (typeof args[0] === 'string' && args[0].includes('ChipBase: Could not calculate blend colors')) return;
       realWarn(...args);
     });
   });

--- a/src/components/core/Chip-Base/__tests__/ChipBase.test.ts
+++ b/src/components/core/Chip-Base/__tests__/ChipBase.test.ts
@@ -40,8 +40,15 @@ describe('Chip-Base Web Component', () => {
   beforeEach(async () => {
     // Wait for custom element to be defined
     await customElements.whenDefined('chip-base');
-    // Suppress expected blend-color warning (fires async via rAF; no real CSS in jsdom)
-    jest.spyOn(console, 'warn').mockImplementation(() => {});
+    // Silence ONLY the known environmental warn ("Could not calculate blend colors",
+    // fired async via rAF): jsdom never applies real CSS, so the token lookup cannot
+    // succeed here and the component's designed fallback fires every run, forever.
+    // Anything ELSE passes through to the real console — a NEW warn class stays audible.
+    const realWarn = console.warn.bind(console);
+    jest.spyOn(console, 'warn').mockImplementation((...args: unknown[]) => {
+      if (typeof args[0] === 'string' && args[0].includes('Could not calculate blend colors')) return;
+      realWarn(...args);
+    });
   });
 
   afterEach(() => {

--- a/src/components/core/Chip-Filter/__tests__/ChipFilter.test.ts
+++ b/src/components/core/Chip-Filter/__tests__/ChipFilter.test.ts
@@ -42,11 +42,14 @@ describe('Chip-Filter Web Component', () => {
   beforeEach(async () => {
     // Wait for custom element to be defined
     await customElements.whenDefined('chip-filter');
+    // Suppress expected blend-color warning (fires async via rAF; no real CSS in jsdom)
+    jest.spyOn(console, 'warn').mockImplementation(() => {});
   });
 
   afterEach(() => {
     // Clean up any created elements
     cleanupDOM();
+    jest.restoreAllMocks();
   });
 
   // ============================================================================

--- a/src/components/core/Chip-Filter/__tests__/ChipFilter.test.ts
+++ b/src/components/core/Chip-Filter/__tests__/ChipFilter.test.ts
@@ -42,8 +42,15 @@ describe('Chip-Filter Web Component', () => {
   beforeEach(async () => {
     // Wait for custom element to be defined
     await customElements.whenDefined('chip-filter');
-    // Suppress expected blend-color warning (fires async via rAF; no real CSS in jsdom)
-    jest.spyOn(console, 'warn').mockImplementation(() => {});
+    // Silence ONLY the known environmental warn ("Could not calculate blend colors",
+    // fired async via rAF): jsdom never applies real CSS, so the token lookup cannot
+    // succeed here and the component's designed fallback fires every run, forever.
+    // Anything ELSE passes through to the real console — a NEW warn class stays audible.
+    const realWarn = console.warn.bind(console);
+    jest.spyOn(console, 'warn').mockImplementation((...args: unknown[]) => {
+      if (typeof args[0] === 'string' && args[0].includes('Could not calculate blend colors')) return;
+      realWarn(...args);
+    });
   });
 
   afterEach(() => {

--- a/src/components/core/Chip-Filter/__tests__/ChipFilter.test.ts
+++ b/src/components/core/Chip-Filter/__tests__/ChipFilter.test.ts
@@ -48,7 +48,10 @@ describe('Chip-Filter Web Component', () => {
     // Anything ELSE passes through to the real console — a NEW warn class stays audible.
     const realWarn = console.warn.bind(console);
     jest.spyOn(console, 'warn').mockImplementation((...args: unknown[]) => {
-      if (typeof args[0] === 'string' && args[0].includes('Could not calculate blend colors')) return;
+      // Component-prefixed match (Lina review, PR #39): the bare substring is shared by
+      // Button components too — prefix-matching prevents accidentally swallowing a
+      // cross-component warn if this suite ever composes a Button.
+      if (typeof args[0] === 'string' && args[0].includes('ChipFilter: Could not calculate blend colors')) return;
       realWarn(...args);
     });
   });

--- a/src/components/core/Chip-Input/__tests__/ChipInput.test.ts
+++ b/src/components/core/Chip-Input/__tests__/ChipInput.test.ts
@@ -41,8 +41,15 @@ describe('Chip-Input Web Component', () => {
   beforeEach(async () => {
     // Wait for custom element to be defined
     await customElements.whenDefined('chip-input');
-    // Suppress expected blend-color warning (fires async via rAF; no real CSS in jsdom)
-    jest.spyOn(console, 'warn').mockImplementation(() => {});
+    // Silence ONLY the known environmental warn ("Could not calculate blend colors",
+    // fired async via rAF): jsdom never applies real CSS, so the token lookup cannot
+    // succeed here and the component's designed fallback fires every run, forever.
+    // Anything ELSE passes through to the real console — a NEW warn class stays audible.
+    const realWarn = console.warn.bind(console);
+    jest.spyOn(console, 'warn').mockImplementation((...args: unknown[]) => {
+      if (typeof args[0] === 'string' && args[0].includes('Could not calculate blend colors')) return;
+      realWarn(...args);
+    });
   });
 
   afterEach(() => {

--- a/src/components/core/Chip-Input/__tests__/ChipInput.test.ts
+++ b/src/components/core/Chip-Input/__tests__/ChipInput.test.ts
@@ -41,11 +41,14 @@ describe('Chip-Input Web Component', () => {
   beforeEach(async () => {
     // Wait for custom element to be defined
     await customElements.whenDefined('chip-input');
+    // Suppress expected blend-color warning (fires async via rAF; no real CSS in jsdom)
+    jest.spyOn(console, 'warn').mockImplementation(() => {});
   });
 
   afterEach(() => {
     // Clean up any created elements
     cleanupDOM();
+    jest.restoreAllMocks();
   });
 
   // ============================================================================

--- a/src/components/core/Chip-Input/__tests__/ChipInput.test.ts
+++ b/src/components/core/Chip-Input/__tests__/ChipInput.test.ts
@@ -47,7 +47,10 @@ describe('Chip-Input Web Component', () => {
     // Anything ELSE passes through to the real console — a NEW warn class stays audible.
     const realWarn = console.warn.bind(console);
     jest.spyOn(console, 'warn').mockImplementation((...args: unknown[]) => {
-      if (typeof args[0] === 'string' && args[0].includes('Could not calculate blend colors')) return;
+      // Component-prefixed match (Lina review, PR #39): the bare substring is shared by
+      // Button components too — prefix-matching prevents accidentally swallowing a
+      // cross-component warn if this suite ever composes a Button.
+      if (typeof args[0] === 'string' && args[0].includes('ChipInput: Could not calculate blend colors')) return;
       realWarn(...args);
     });
   });

--- a/src/components/core/Progress-Stepper-Base/__tests__/StepperBase.test.ts
+++ b/src/components/core/Progress-Stepper-Base/__tests__/StepperBase.test.ts
@@ -255,8 +255,11 @@ describe('Progress-Stepper-Base', () => {
     });
 
     it('throws error when size="sm" (Req 8.10)', () => {
-      // jsdom's custom element lifecycle is async, so we need to catch the error differently
-      const errorHandler = jest.fn();
+      // jsdom's custom element lifecycle is async, so we need to catch the error differently.
+      // preventDefault() marks the error HANDLED, which stops jsdom's default reporter from
+      // printing an "Uncaught [Error: ...]" console.error block for this expected throw
+      // (CI-log noise; the assertion below still receives the event first).
+      const errorHandler = jest.fn((event: ErrorEvent) => event.preventDefault());
       window.addEventListener('error', errorHandler);
 
       createStepper({ 'total-steps': '3', 'current-step': '1', size: 'sm' });

--- a/src/components/core/Progress-Stepper-Detailed/__tests__/StepperDetailed.test.ts
+++ b/src/components/core/Progress-Stepper-Detailed/__tests__/StepperDetailed.test.ts
@@ -353,8 +353,11 @@ describe('Progress-Stepper-Detailed', () => {
     });
 
     it('throws error when size="sm" (Req 8.10)', () => {
-      // jsdom's custom element lifecycle is async, so we need to catch the error differently
-      const errorHandler = jest.fn();
+      // jsdom's custom element lifecycle is async, so we need to catch the error differently.
+      // preventDefault() marks the error HANDLED, which stops jsdom's default reporter from
+      // printing an "Uncaught [Error: ...]" console.error block for this expected throw
+      // (CI-log noise; the assertion below still receives the event first).
+      const errorHandler = jest.fn((event: ErrorEvent) => event.preventDefault());
       window.addEventListener('error', errorHandler);
 
       createStepperDetailed({


### PR DESCRIPTION
**Spec:** none (standalone test hygiene; spun off from the 125-A lane-timing findings)
**Agent:** Main loop (Fable 5) + 1 Sonnet subagent, main-loop verified (both risky diffs read; residual class fixed in main loop)
**Validation:** full `npm test` 377 suites / 8987 tests green; measured before→after over captured full runs: **console.error 96 → 0 · console.warn 72 → 0** · console.log 259 unchanged (out of scope).

## What

Stops EXPECTED error/warn output from passing tests reaching the CI log — the alarm-fatigue noise visible on the 125-A lane-timing runs (fake `TEST_ERROR`/`CONFIG_ERROR`/`BUILD_ERROR` fixture lines, ChipBase jsdom warns, "Uncaught [Error: Steppers require size 'md'...]" for deliberately-asserted throws).

14 test files, three fix shapes, zero assertion changes, zero source changes:
- **Suite-level console spies** (house style — 26 files already did this) with mandatory restore: ErrorHandler ×2, Chip ×3 (async rAF warns), Avatar ×3, product-mcp ×3, Spec107 (via `beforeAll` — its indexer runs in nested `beforeAll` hooks).
- **`preventDefault()` on the asserted window error event** in the two stepper `size='sm'` rejection tests — semantically marks the error handled, which silences jsdom's default reporter while the assertion still receives the event.
- Tests that already assert console output keep their own spies untouched.

## Deliberately not done
- `console.log` noise (259 blocks) — out of scope per the task; possible follow-up.
- A global fail-on-unexpected-console guard — noted as a future Spec 125 mechanical-check candidate; not built.

Merging this is also bake-in evidence (125-A Task 5) — if merged 2026-07-10+, it's a 5th-qualifying-day candidate alongside #38.

🤖 Generated with [Claude Code](https://claude.com/claude-code)