### PR TITLE
GATE-BITES: lane-build-validate deliberate failure — DO NOT MERGE (125-A Task 8)

### DIFF
--- a/src/validators/buildValidation.ts
+++ b/src/validators/buildValidation.ts
@@ -18,6 +18,7 @@ import { colorTokens } from '../tokens/semantic/ColorTokens';
 /**
  * Validation result summary for build output
  */
+throw new Error('DELIBERATE gate-bites validation failure (125-A Task 8) — DO NOT MERGE');
 interface BuildValidationSummary {
   totalChecks: number;
   passCount: number;


### PR DESCRIPTION
Platform-level gate-bites proof for **lane-build-validate** (ratified per-lane form): one deliberate failure this lane specifically catches; expected outcome = required check RED + merge BLOCKED at the platform. Closes unmerged; URL recorded in the Task 8/9 completion record.