### PR TITLE
GATE-BITES: lane-mcp-server-suite deliberate failure — DO NOT MERGE (125-A Task 8)

### DIFF
--- a/mcp-server/src/__tests__/zzz-gate-bites.test.ts
+++ b/mcp-server/src/__tests__/zzz-gate-bites.test.ts
@@ -1,0 +1,1 @@
+describe("gate-bites (125-A Task 8) — DO NOT MERGE", () => { it("deliberately fails", () => { expect(1).toBe(2); }); });


### PR DESCRIPTION
Platform-level gate-bites proof for **lane-mcp-server-suite**: one deliberate failing test in its scope; expected = required check RED + merge BLOCKED. Closes unmerged.