### PR TITLE
Fix: MCP servers self-exit on stdin EOF (orphan-leak server half)

### DIFF
--- a/application-mcp-server/src/index.ts
+++ b/application-mcp-server/src/index.ts
@@ -363,6 +363,32 @@ class ComponentMCPServer {
     this.stalenessGate.markIndexed();
     await this.server.connect(transport);
     console.error(`[${SERVER_NAME}] Server running on stdio`);
+    this.setupShutdownHandlers();
+  }
+
+  /**
+   * Self-exit on stdin EOF and fatal signals. A stdio MCP server whose parent client
+   * died (or gracefully closed the pipe) has no one to serve, but the file watcher
+   * keeps the event loop alive forever — found live at Spec 122 U3 (~230 orphaned
+   * servers accumulated across harness runs). Exiting on EOF also makes graceful
+   * client closes immediate: the MCP SDK's StdioClientTransport.close() ends stdin
+   * and waits up to 2s for exactly this exit before escalating to SIGTERM.
+   */
+  private setupShutdownHandlers(): void {
+    let shuttingDown = false;
+    const shutdown = async (): Promise<void> => {
+      if (shuttingDown) return;
+      shuttingDown = true;
+      console.error(`[${SERVER_NAME}] Shutting down...`);
+      this.fileWatcher.stop();
+      await this.server.close();
+      process.exit(0);
+    };
+
+    process.on('SIGINT', shutdown);
+    process.on('SIGTERM', shutdown);
+    process.stdin.on('end', shutdown);
+    process.stdin.on('close', shutdown);
   }
 
   private registerHandlers(): void {

--- a/canonical/generated.lock
+++ b/canonical/generated.lock
@@ -1,4 +1,4 @@
 {
-  "inputClosure": "9d58ad4fa0b474cd084a2bb651c25c2e2596c54d7a01b0cacadcf060a911d823",
+  "inputClosure": "f8d356153404de4c3d354c3fb291f64d6a05cda1854a6df6892cab944e6c5ca2",
   "outputs": "e16b7103324b54c2dd44e8ca09b35849aa14cf952485d220d773af5531e95dfb"
 }

--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -346,7 +346,15 @@ class MCPDocumentationServer {
   }
 
   /**
-   * Set up graceful shutdown handlers
+   * Set up graceful shutdown handlers.
+   *
+   * stdin EOF ('end'/'close') is a first-class shutdown trigger: a stdio MCP server
+   * whose parent client died (or gracefully closed the pipe) has no one to serve, but
+   * the file watcher keeps the event loop alive forever — found live at Spec 122 U3
+   * (~230 orphaned servers accumulated across harness runs, wedging later boots).
+   * Self-exiting on EOF also makes graceful client closes immediate: the MCP SDK's
+   * StdioClientTransport.close() ends stdin and waits up to 2s for exactly this exit
+   * before escalating to SIGTERM.
    */
   private setupShutdownHandlers(): void {
     const shutdown = async () => {
@@ -356,6 +364,8 @@ class MCPDocumentationServer {
 
     process.on('SIGINT', shutdown);
     process.on('SIGTERM', shutdown);
+    process.stdin.on('end', shutdown);
+    process.stdin.on('close', shutdown);
   }
 }
 

--- a/product-mcp-server/src/index.ts
+++ b/product-mcp-server/src/index.ts
@@ -195,6 +195,33 @@ class ProductMCPServer {
     const transport = new StdioServerTransport();
     await this.server.connect(transport);
     console.error(`[${SERVER_NAME}] Server running on stdio`);
+    this.setupShutdownHandlers();
+  }
+
+  /**
+   * Self-exit on stdin EOF and fatal signals. A stdio MCP server whose parent client
+   * died (or gracefully closed the pipe) has no one to serve, but the file watcher
+   * keeps the event loop alive forever — found live at Spec 122 U3 (~230 orphaned
+   * servers accumulated across harness runs, this server the most-leaked of the
+   * three). Exiting on EOF also makes graceful client closes immediate: the MCP
+   * SDK's StdioClientTransport.close() ends stdin and waits up to 2s for exactly
+   * this exit before escalating to SIGTERM.
+   */
+  private setupShutdownHandlers(): void {
+    let shuttingDown = false;
+    const shutdown = async (): Promise<void> => {
+      if (shuttingDown) return;
+      shuttingDown = true;
+      console.error(`[${SERVER_NAME}] Shutting down...`);
+      this.fileWatcher?.close();
+      await this.server.close();
+      process.exit(0);
+    };
+
+    process.on('SIGINT', shutdown);
+    process.on('SIGTERM', shutdown);
+    process.stdin.on('end', shutdown);
+    process.stdin.on('close', shutdown);
   }
 
   private startFileWatcher(): void {


### PR DESCRIPTION
**Spec**: non-spec fix (routed item from 122-agent-generator U3 — `.kiro/specs/122-agent-generator/cutover/lina-cutover-report.md` § Routed items 3)
**Task**: spawned task (Peter-authorized via task chip, 2026-07-11)
**Agent**: Claude (main loop)
**Unit**: fix/mcp-servers-stdin-eof (single-commit fix unit)

## What

All three MCP servers (docs, application, product) now self-exit — via their graceful shutdown path — when stdin closes, i.e. when their parent client dies or closes the pipe. Previously each server's file watcher kept the event loop alive forever: ~230 orphaned server processes had accumulated since 2026-06-29, wedging and slowing local check runs (diagnosed live during Lina's cutover).

- `mcp-server/src/index.ts`: stdin 'end'/'close' added to the existing shutdown handlers
- `application-mcp-server/src/index.ts` + `product-mcp-server/src/index.ts`: had NO shutdown handlers; now handle stdin EOF + SIGINT/SIGTERM gracefully (idempotent, boot-path-only — library imports unaffected)

This is the server-side complement of U3's client-side kill-on-exit guard — and the stronger half: the OS closes the pipe even on client SIGKILL, so this covers every client-death mode. It also makes graceful closes immediate (the MCP SDK's `StdioClientTransport.close()` waits up to 2s for exactly this exit).

## Ownership note

Touches three server surfaces (docs = Civitas/Thurgood; application = Lina's writeScope; product = product agents) under Peter's direct task authorization; behavior added is identical across the three.

## Validation (local)

- Each compiled server exits code 0 within **4–6ms** of stdin EOF (previously: never)
- generate + diff-guard + C7 complete in **~4s combined**; zero orphans after runs
- mcp-server 601/601 · application-mcp-server 320/320 · root `npm test` 8987/8987 · agent-generator lane 322/322
- `canonical/generated.lock` refreshed (diff-guard input closure includes the rebuilt dists)

🤖 Generated with [Claude Code](https://claude.com/claude-code)