### PR TITLE
Remove Button-CTA disabled state per adjudication (no-disabled-states philosophy)

### DIFF
--- a/.kiro/issues/button-cta-disabled-state-adjudication.md
+++ b/.kiro/issues/button-cta-disabled-state-adjudication.md
@@ -1,0 +1,87 @@
+# Button-CTA: Disabled-State Adjudication — RULED: REMOVE
+
+**Date**: 2026-07-15
+**Ruled by**: Peter
+**Owner recommendation**: Lina (remove)
+**Source**: Routed out of Spec 125-B U2 (deliberately not resolved inside the CI work)
+**Status**: RESOLVED — removal implemented
+
+---
+
+## Question
+
+Button-CTA was the only component in the corpus with a live `state_disabled`
+contract, while 16+ components carry the standardized exclusion
+("DesignerPunk does not support disabled states for usability and
+accessibility reasons. If an action is unavailable, the component should not
+be rendered."). Was Button-CTA's disabled state deliberate, or an oversight?
+
+## Findings (Lina)
+
+- Button-CTA shipped 2025-11-20 (Spec 005) with `disabled` designed in as a
+  first-class prop on all three platforms. The no-disabled-states philosophy
+  first appears **seven weeks later** (2026-01-07, Spec 038). Button-CTA was
+  grandfathered, never retrofitted.
+- Spec 066 (2026-03-01) adjudicated the 9 excluded components as intentional
+  and removed Input-Text-Base's live `state_disabled` contract — but
+  explicitly left Button-CTA out of scope (task-3.3-completion.md note).
+  Deferred, not affirmed.
+- Spec 112 maintained the contract (OKLCH ΔC thresholds) and
+  `InteractionStateAudit.test.ts` codified "Only Button-CTA has a disabled
+  state in DesignerPunk" — the anomaly was known but never adjudicated.
+- No product consumers used the `disabled` prop (demo page and blend audit
+  test only).
+
+## Ruling
+
+**Remove** — align Button-CTA with the no-disabled-states philosophy.
+`state_loading` covers in-flight async actions; validate-on-press covers
+form-invalid; hide covers unavailable actions. The philosophy now holds
+corpus-wide with zero exceptions.
+
+## Changes (this branch)
+
+- `contracts.yaml`: `state_disabled` contract removed → standardized
+  `excludes.state_disabled` block; disabled references removed from
+  focusable/pressable/hover/pressed contracts.
+- `types.ts`: `disabled` prop removed; NO DISABLED STATES header added.
+- Platforms: disabled handling removed from web (`.web.ts` + `.web.css`),
+  iOS (`.ios.swift`), Android (`.android.kt`). Buttons no longer render
+  `disabled`/`aria-disabled` attributes.
+- Schema: `disabled` property and `blend.disabledDesaturate` token reference
+  removed from `Button-CTA.schema.yaml`.
+- Tests: disabled-behavior tests replaced with exclusion-guard tests
+  (contracts.yaml shape, no observed attribute, consumer-set `disabled`
+  attribute ignored). `css-bundling.test.ts` flipped to assert the browser
+  bundle ships NO disabled styles. `InteractionStateAudit.test.ts` disabled
+  case reduced to calculator-capability only.
+- Docs/demos: README, examples, `demos/button-cta-demo.html`,
+  `governance/Component-Family-Button.md`,
+  `governance/Component-Development-Guide.md`,
+  `governance/browser-distribution-guide.md`, `docs/token-system-overview.md`.
+
+## Follow-ups
+
+1. **Ada — token deprecation**: `blend.disabledDesaturate` has no remaining
+   component consumers (still referenced by blend utilities
+   `disabledColor`/`disabledBlend` and blend tests). Deprecation is Ada's
+   call; the calculator capability and token were deliberately left intact.
+2. **125-B U2 register note**: `governance/classification-map.md`'s WCAG-floor
+   note excluding `state_disabled` "pending the Button-CTA disabled-state
+   adjudication" (and stemma-pre-arm-adjudication.md §7) should be updated to
+   reference this ruling: adjudicated REMOVE, 2026-07-15 — `state_disabled`
+   may now join the per-literal presence assertion with no carve-out. That
+   register lives on the in-flight U2 branch, not on `main` at time of ruling.
+3. **U1b candidate row (log, don't build)**: philosophy-conformance check
+   "components must not declare disabled states unless allowlisted" — reds on
+   PRESENCE of a violation. Allowlist is now empty; the check needs no
+   Button-CTA carve-out.
+4. **Versioning**: removing a public prop from `@3fn/core`'s flagship button
+   is a breaking API change — flag for the next major-version decision.
+
+## Validation
+
+- `npx tsc --noEmit` clean.
+- `npm test`: 8983/8983 pass.
+- `npm run test:all`: 9059/9059 pass (idle re-run; an interleaved first run
+  showed 2 wall-clock-sensitive performance failures, gone when serialized).

--- a/demos/button-cta-demo.html
+++ b/demos/button-cta-demo.html
@@ -202,50 +202,10 @@
          ============================================================ -->
     <div class="demo-section">
       <h2>4. State Variants</h2>
-      <p>Buttons support disabled state with desaturated styling. Disabled buttons are non-interactive and not keyboard focusable.</p>
-
-      <h3>Disabled State</h3>
-      <div class="demo-row">
-        <div class="demo-item">
-          <button-cta label="Primary Disabled" variant="primary" disabled></button-cta>
-          <span class="demo-item-label">Primary (12% desaturated)</span>
-        </div>
-        <div class="demo-item">
-          <button-cta label="Secondary Disabled" variant="secondary" disabled></button-cta>
-          <span class="demo-item-label">Secondary disabled</span>
-        </div>
-        <div class="demo-item">
-          <button-cta label="Tertiary Disabled" variant="tertiary" disabled></button-cta>
-          <span class="demo-item-label">Tertiary disabled</span>
-        </div>
-      </div>
-
-      <h3>Disabled with Icons</h3>
-      <div class="demo-row">
-        <div class="demo-item">
-          <button-cta label="Submit" variant="primary" icon="check" disabled></button-cta>
-          <span class="demo-item-label">Disabled + icon</span>
-        </div>
-        <div class="demo-item">
-          <button-cta label="Cancel" variant="secondary" icon="x" disabled></button-cta>
-          <span class="demo-item-label">Disabled + icon</span>
-        </div>
-      </div>
-
-      <h3>Enabled vs Disabled Comparison</h3>
-      <div class="demo-row">
-        <div class="demo-item">
-          <button-cta label="Enabled" variant="primary" icon="arrow-right"></button-cta>
-          <span class="demo-item-label">Enabled</span>
-        </div>
-        <div class="demo-item">
-          <button-cta label="Disabled" variant="primary" icon="arrow-right" disabled></button-cta>
-          <span class="demo-item-label">Disabled</span>
-        </div>
-      </div>
+      <p>Button-CTA has no disabled state. DesignerPunk does not support disabled states for usability and accessibility reasons — if an action is unavailable, the component should not be rendered.</p>
 
       <div class="demo-note">
-        <strong>Accessibility:</strong> Disabled buttons use <code>desaturate()</code> blend utility (12% less saturated) instead of opacity, maintaining color contrast for accessibility. The <code>cursor: not-allowed</code> and <code>aria-disabled="true"</code> attributes communicate the non-interactive state.
+        <strong>No disabled state:</strong> Disabled buttons remove affordance without explanation. Use alternative patterns instead: hide the button when the action is unavailable, keep it interactive and validate on press, or use the loading state for in-flight async operations.
       </div>
     </div>
 
@@ -286,7 +246,7 @@
       </div>
 
       <div class="demo-note">
-        <strong>State color calculation:</strong> Uses <code>darkerBlend()</code> for hover (8%) and pressed (12%), and <code>desaturate()</code> for disabled (12%). These are calculated at runtime using theme-aware blend utilities for cross-platform consistency with iOS and Android.
+        <strong>State color calculation:</strong> Uses <code>darkerBlend()</code> for hover (8%) and pressed (12%). These are calculated at runtime using theme-aware blend utilities for cross-platform consistency with iOS and Android.
       </div>
     </div>
 
@@ -324,9 +284,6 @@
           <div class="demo-item">
             <button-cta id="event-btn-secondary" label="Secondary Action" variant="secondary" icon="settings"></button-cta>
           </div>
-          <div class="demo-item">
-            <button-cta id="event-btn-disabled" label="Disabled (no events)" variant="primary" disabled></button-cta>
-          </div>
         </div>
 
         <div style="display: flex; justify-content: space-between; align-items: center; margin-block-start: var(--space-100);">
@@ -339,7 +296,7 @@
       </div>
 
       <div class="demo-note">
-        <strong>Event details:</strong> The <code>press</code> event includes <code>event.detail.originalEvent</code> containing the underlying click or keyboard event. Disabled buttons do not fire events.
+        <strong>Event details:</strong> The <code>press</code> event includes <code>event.detail.originalEvent</code> containing the underlying click or keyboard event.
       </div>
     </div>
 
@@ -363,10 +320,6 @@
             <span class="demo-item-label">Tab → Enter/Space</span>
           </div>
           <div class="demo-item">
-            <button-cta label="Skipped" variant="primary" size="medium" disabled></button-cta>
-            <span class="demo-item-label">Disabled (skipped)</span>
-          </div>
-          <div class="demo-item">
             <button-cta label="Third" variant="tertiary" size="medium"></button-cta>
             <span class="demo-item-label">Tab → Enter/Space</span>
           </div>
@@ -377,7 +330,6 @@
       <ul class="demo-token-list">
         <li><code>role="button"</code> — semantic button role</li>
         <li><code>aria-label</code> — set to the label text</li>
-        <li><code>aria-disabled</code> — reflects disabled state</li>
         <li><code>aria-hidden="true"</code> — on icon container (decorative)</li>
       </ul>
 
@@ -459,9 +411,6 @@
 &lt;!-- With icon --&gt;
 &lt;button-cta label="Continue" variant="primary" icon="arrow-right"&gt;&lt;/button-cta&gt;
 
-&lt;!-- Disabled state --&gt;
-&lt;button-cta label="Unavailable" variant="primary" disabled&gt;&lt;/button-cta&gt;
-
 &lt;!-- No-wrap for constrained spaces --&gt;
 &lt;button-cta label="Long Label Text" variant="primary" no-wrap="true"&gt;&lt;/button-cta&gt;
 
@@ -488,8 +437,6 @@ btn.addEventListener('press', () =&gt; console.log('Pressed!'));
 document.body.appendChild(btn);
 
 // Dynamic state changes
-btn.disabled = true;   // Disable
-btn.disabled = false;  // Re-enable
 btn.label = 'Updated'; // Change label
 btn.icon = 'check';    // Change icon</pre>
     </div>
@@ -544,10 +491,6 @@ btn.icon = 'check';    // Change icon</pre>
       logEvent('Secondary Action', 'press');
     });
 
-    // Disabled button should not fire events, but listen anyway to verify
-    document.getElementById('event-btn-disabled').addEventListener('press', function() {
-      logEvent('Disabled Button', 'press (unexpected!)');
-    });
   </script>
 </body>
 </html>

--- a/docs/token-system-overview.md
+++ b/docs/token-system-overview.md
@@ -637,7 +637,7 @@ All four core components use blend utilities:
 
 | Component | Blend Usage |
 |-----------|-------------|
-| ButtonCTA | hover (darkerBlend), pressed (darkerBlend), disabled (desaturate), icon (lighterBlend) |
+| ButtonCTA | hover (darkerBlend), pressed (darkerBlend), icon (lighterBlend) |
 | TextInputField | focus (saturate), disabled (desaturate) |
 | Container | hover (darkerBlend) |
 | Icon | optical balance (lighterBlend) |

--- a/governance/Component-Development-Guide.md
+++ b/governance/Component-Development-Guide.md
@@ -1492,7 +1492,6 @@ All component-scoped CSS custom properties MUST use the `--_[abbrev]-*` naming p
   /* Component-scoped properties - internal, calculated */
   --_cta-hover-bg: /* calculated by blend utilities */;
   --_cta-pressed-bg: /* calculated by blend utilities */;
-  --_cta-disabled-bg: /* calculated by blend utilities */;
 }
 
 .button-cta {

--- a/governance/Component-Family-Button.md
+++ b/governance/Component-Family-Button.md
@@ -32,7 +32,7 @@ The Buttons family provides interactive components for triggering user actions w
 
 - **Visual Hierarchy**: Three visual variants (primary, secondary, tertiary) establish clear action hierarchy
 - **Size Variants**: Three sizes (small, medium, large) for different contexts and emphasis levels
-- **Interaction States**: Comprehensive hover, pressed, disabled, and loading states
+- **Interaction States**: Comprehensive hover, pressed, and loading states (no disabled state — DesignerPunk philosophy)
 - **Accessibility First**: WCAG 2.1 AA compliant with keyboard navigation and screen reader support
 - **Cross-Platform Consistent**: Platform-appropriate feedback (ripple on Android, scale on iOS)
 
@@ -98,7 +98,7 @@ Button-CTA uses the `[Family]-[Type]` pattern without a variant suffix because i
 
 ### Base Contracts
 
-All Button-CTA instances implement these 7 foundational contracts:
+All Button-CTA instances implement these 6 foundational contracts:
 
 | Contract | Description | WCAG | Platforms |
 |----------|-------------|------|-----------|
@@ -106,7 +106,6 @@ All Button-CTA instances implement these 7 foundational contracts:
 | `pressable` | Responds to press/click events | 2.1.1 | web, ios, android |
 | `hover_state` | Visual feedback on hover (desktop) | 1.4.13 | web |
 | `pressed_state` | Visual feedback when pressed | 2.4.7 | web, ios, android |
-| `disabled_state` | Prevents interaction when disabled | 4.1.2 | web, ios, android |
 | `loading_state` | Shows loading indicator during async | 4.1.3 | web, ios, android |
 | `focus_ring` | WCAG 2.4.7 focus visible indicator | 2.4.7 | web, ios, android |
 
@@ -116,7 +115,7 @@ All Button-CTA instances implement these 7 foundational contracts:
 
 **Description**: Component can receive keyboard focus via Tab key navigation.
 
-**Behavior**: Focus state is visually indicated with a focus ring. Focus is managed appropriately when disabled state changes. Disabled buttons are not keyboard focusable.
+**Behavior**: Focus state is visually indicated with a focus ring.
 
 **WCAG Compliance**: 2.1.1 Keyboard, 2.4.7 Focus Visible
 
@@ -124,7 +123,7 @@ All Button-CTA instances implement these 7 foundational contracts:
 
 **Description**: Component responds to click, tap, Enter key, and Space key.
 
-**Behavior**: Press triggers the onPress callback when not disabled. Platform-appropriate feedback is provided during press (ripple on Android, scale on iOS).
+**Behavior**: Press triggers the onPress callback. Platform-appropriate feedback is provided during press (ripple on Android, scale on iOS).
 
 **WCAG Compliance**: 2.1.1 Keyboard
 
@@ -143,14 +142,6 @@ All Button-CTA instances implement these 7 foundational contracts:
 **Behavior**: Component shows visual feedback during active press/click. Uses `blend.pressedDarker` token (12% darker). Platform-specific feedback: Web uses background color change, iOS uses scale animation with haptic feedback, Android uses ripple effect with haptic feedback.
 
 **WCAG Compliance**: 2.4.7 Focus Visible
-
-#### disabled_state
-
-**Description**: Prevents interaction when disabled.
-
-**Behavior**: When disabled, component cannot receive focus, cannot be clicked/tapped, uses desaturated colors (`blend.disabledDesaturate` - 12% less saturated), shows `cursor: not-allowed` (web), and communicates disabled state to assistive technology.
-
-**WCAG Compliance**: 4.1.2 Name, Role, Value
 
 #### focus_ring
 
@@ -179,7 +170,6 @@ All Button-CTA instances implement these 7 foundational contracts:
 | `variant` | `'primary' \| 'secondary' \| 'tertiary'` | No | `'primary'` | Visual variant for hierarchy |
 | `icon` | `IconName` | No | - | Optional leading icon |
 | `noWrap` | `boolean` | No | `false` | Truncate text instead of wrapping |
-| `disabled` | `boolean` | No | `false` | Disabled state |
 | `onPress` | `() => void` | Yes | - | Press callback |
 | `testID` | `string` | No | - | Test identifier |
 
@@ -503,7 +493,6 @@ Button components rely on three semantic concepts:
 | Icon | `icon.size100`, `icon.size125` | Icon sizing |
 | Blend | `blend.hoverDarker` | Hover state (8% darker) |
 | Blend | `blend.pressedDarker` | Pressed state (12% darker) |
-| Blend | `blend.disabledDesaturate` | Disabled state (12% less saturated) |
 
 **Why Semantic Concept Tokens**:
 - **Action concept**: `color.action.primary` clearly indicates emphasized interactive elements
@@ -650,7 +639,6 @@ iOS uses scale transforms + color blends for all press feedback. The ripple dist
 
 All platforms implement the same behavioral contracts:
 - Press feedback timing matches across platforms
-- Disabled state appearance is mathematically equivalent
 - Focus ring appearance is consistent
 - Touch targets meet platform guidelines
 

--- a/governance/browser-distribution-guide.md
+++ b/governance/browser-distribution-guide.md
@@ -345,9 +345,6 @@ Call-to-action button with variants, sizes, and icon support.
 <button-cta label="Primary" variant="primary"></button-cta>
 <button-cta label="Secondary" variant="secondary"></button-cta>
 <button-cta label="Tertiary" variant="tertiary"></button-cta>
-
-<!-- Disabled state -->
-<button-cta label="Disabled" variant="primary" disabled></button-cta>
 ```
 
 **Events:**

--- a/src/__tests__/browser-distribution/css-bundling.test.ts
+++ b/src/__tests__/browser-distribution/css-bundling.test.ts
@@ -183,11 +183,13 @@ describe('CSS Bundling for Browser Distribution', () => {
       expect(bundleContent).toMatch(/:hover/);
     });
 
-    it('should contain disabled state styles', () => {
+    it('should not contain disabled state styles (no-disabled-states philosophy)', () => {
       const bundleContent = fs.readFileSync(ESM_BUNDLE_PATH, 'utf-8');
-      
-      // Components should have disabled styles
-      expect(bundleContent).toMatch(/:disabled|--disabled/);
+
+      // DesignerPunk does not support disabled states: if an action is
+      // unavailable, the component should not be rendered. No component CSS
+      // should ship disabled selectors or modifier classes.
+      expect(bundleContent).not.toMatch(/:disabled|--disabled/);
     });
   });
 

--- a/src/blend/__tests__/InteractionStateAudit.test.ts
+++ b/src/blend/__tests__/InteractionStateAudit.test.ts
@@ -13,7 +13,10 @@
  *   hover:    ΔL ∈ [0.02, 0.05], preserve chroma
  *   pressed:  ΔL ∈ [0.05, 0.10], preserve chroma
  *   focused:  ΔC ≥ 0.02 (chroma boost)
- *   disabled: ΔC ≥ 0.03 (chroma reduction)
+ *   disabled: ΔC ≥ 0.03 (chroma reduction) — calculator capability only;
+ *             no component declares a disabled state (state_disabled removed
+ *             from Button-CTA 2026-07-15, completing the no-disabled-states
+ *             philosophy across the corpus)
  *
  * Components audited:
  *   Button-CTA, Button-Icon, Button-VerticalList-Item, Chip-Base,
@@ -125,14 +128,12 @@ describe('Spec 112 Task 5.1: Interaction State Visual Audit', () => {
   });
 
   describe('Disabled state (ΔC ≥ 0.03 reduction)', () => {
-    // Only Button-CTA has a disabled state in DesignerPunk
-    const cases: [string, Oklch][] = [
-      ['Button-CTA (primary)', primaryButton],
-    ];
-
-    it.each(cases)('%s — ΔC reduction meets minimum', (name, base) => {
-      const result = calc.interactionBlend(base, 'disabled', lightSurface);
-      const dc = deltaC(base, result);
+    // No component declares a disabled state (no-disabled-states philosophy).
+    // This validates the calculator capability only, kept until the
+    // blend.disabledDesaturate token's deprecation is adjudicated (Ada).
+    it('calculator disabled blend — ΔC reduction meets minimum', () => {
+      const result = calc.interactionBlend(primaryButton, 'disabled', lightSurface);
+      const dc = deltaC(primaryButton, result);
       // dc should be negative (chroma reduced), absolute value ≥ 0.03
       expect(dc).toBeLessThan(0);
       expect(Math.abs(dc)).toBeGreaterThanOrEqual(INTERACTION_THRESHOLDS.disabled.deltaC.min);

--- a/src/components/core/Button-CTA/Button-CTA.schema.yaml
+++ b/src/components/core/Button-CTA/Button-CTA.schema.yaml
@@ -90,20 +90,12 @@ properties:
       When true, text is truncated with ellipsis instead of wrapping.
       Default (false) allows text wrapping for accessibility and i18n support.
   
-  disabled:
-    type: boolean
-    required: false
-    default: false
-    description: |
-      When true, button is non-interactive with disabled visual styling.
-      Disabled buttons are not keyboard focusable and onPress is not called.
-  
   onPress:
     type: "() => void"
     required: true
     description: |
       Callback function invoked when button is clicked, tapped, or activated
-      via keyboard (Enter/Space). Not called when disabled.
+      via keyboard (Enter/Space).
   
   testID:
     type: string
@@ -153,7 +145,6 @@ tokens:
   blend:
     - blend.hoverDarker
     - blend.pressedDarker
-    - blend.disabledDesaturate
     - blend.iconLighter
   component:
     - buttonCTA.minWidth.small
@@ -247,11 +238,10 @@ accessibility:
     - "1.4.11 Non-text Contrast - Focus ring meets 3:1 contrast"
     - "2.1.1 Keyboard - Fully keyboard accessible (Tab, Enter, Space)"
     - "2.4.7 Focus Visible - Clear focus indicator with :focus-visible"
-    - "4.1.2 Name, Role, Value - Proper ARIA attributes and disabled state"
+    - "4.1.2 Name, Role, Value - Proper ARIA attributes"
     - "2.5.5 Target Size - Touch targets meet 44px minimum"
   aria_attributes:
     - role: button (implicit from semantic element)
-    - aria-disabled: true when disabled
     - aria-label: label prop value
   keyboard_navigation:
     - Tab: Move focus to/from button

--- a/src/components/core/Button-CTA/README.md
+++ b/src/components/core/Button-CTA/README.md
@@ -41,9 +41,10 @@ This component guarantees 7 behavioral contracts across all platforms:
 | `pressable` | Responds to press/click events | web, ios, android | 2.1.1 |
 | `hover_state` | Visual feedback on hover | web | 1.4.13 |
 | `pressed_state` | Visual feedback when pressed | web, ios, android | 2.4.7 |
-| `disabled_state` | Prevents interaction when disabled | web, ios, android | 4.1.2 |
 | `loading_state` | Shows loading indicator | web, ios, android | 4.1.3 |
 | `focus_ring` | WCAG 2.4.7 focus visible indicator | web, ios, android | 2.4.7 |
+
+**Excluded**: `state_disabled` — DesignerPunk does not support disabled states for usability and accessibility reasons. If an action is unavailable, the component should not be rendered (adjudicated 2026-07-15).
 
 ---
 
@@ -62,7 +63,6 @@ This component guarantees 7 behavioral contracts across all platforms:
   variant="primary"
   icon="arrow-right"
   no-wrap="false"
-  disabled="false"
   test-id="submit-button"
 ></button-cta>
 ```
@@ -122,7 +122,6 @@ ButtonCTA(
 | `variant` | `'primary' \| 'secondary' \| 'tertiary'` | No | `'primary'` | Button visual variant |
 | `icon` | `IconName` | No | - | Optional leading icon |
 | `noWrap` | `boolean` | No | `false` | Prevent text wrapping |
-| `disabled` | `boolean` | No | `false` | Disable button interaction |
 | `onPress` | `() => void` | ✅ Yes | - | Press/click handler |
 | `testID` | `string` | No | - | Test identifier |
 
@@ -177,7 +176,6 @@ ButtonCTA(
 ### Blend
 - `blend.hoverDarker` - Hover state (8% darker)
 - `blend.pressedDarker` - Pressed state (12% darker)
-- `blend.disabledDesaturate` - Disabled state (12% less saturated)
 - `blend.iconLighter` - Icon optical balance (8% lighter)
 
 ### Accessibility
@@ -205,7 +203,7 @@ ButtonCTA(
 | 2.1.1 Keyboard | ✅ | Fully keyboard accessible (Tab, Enter, Space) |
 | 2.4.7 Focus Visible | ✅ | Clear focus indicator with :focus-visible |
 | 2.5.5 Target Size | ✅ | Touch targets meet 44px minimum |
-| 4.1.2 Name, Role, Value | ✅ | Proper ARIA attributes and disabled state |
+| 4.1.2 Name, Role, Value | ✅ | Proper ARIA attributes |
 
 ### Keyboard Navigation
 
@@ -219,7 +217,6 @@ ButtonCTA(
 
 - Semantic `<button>` element provides implicit role
 - `aria-label` set from label prop
-- `aria-disabled="true"` when disabled
 - State changes announced to assistive technology
 
 ---

--- a/src/components/core/Button-CTA/__tests__/ButtonCTA.test.ts
+++ b/src/components/core/Button-CTA/__tests__/ButtonCTA.test.ts
@@ -7,7 +7,7 @@
  * Unit tests for Button-CTA component rendering
  * 
  * Tests component rendering with various props, size variants, variant styles,
- * icon integration, text wrapping, and disabled state.
+ * icon integration, and text wrapping.
  * 
  * Stemma System Naming: [Family]-[Type] = Button-CTA
  * Component Type: Standalone (no behavioral variants)
@@ -66,7 +66,6 @@ describe('Button-CTA Component Rendering', () => {
     buttonVariant?: 'primary' | 'secondary' | 'tertiary';
     icon?: string;
     noWrap?: boolean;
-    disabled?: boolean;
     testID?: string;
   }): ButtonCTA {
     // Create element - constructor runs and attaches shadow DOM
@@ -78,7 +77,6 @@ describe('Button-CTA Component Rendering', () => {
     if (props.buttonVariant) button.buttonVariant = props.buttonVariant;
     if (props.icon) button.icon = props.icon;
     if (props.noWrap !== undefined) button.noWrap = props.noWrap;
-    if (props.disabled !== undefined) button.disabled = props.disabled;
     if (props.testID) button.testID = props.testID;
     
     // Append to container
@@ -287,40 +285,48 @@ describe('Button-CTA Component Rendering', () => {
     });
   });
   
-  describe('Disabled State', () => {
-    it('should render disabled button with correct attributes', () => {
-      // Requirement: Disabled prop prevents interaction
-      const button = createButton({ label: 'Disabled Button', disabled: true });
-      
-      const shadowButton = button.shadowRoot?.querySelector('button');
-      expect(shadowButton?.hasAttribute('disabled')).toBe(true);
-      expect(shadowButton?.getAttribute('aria-disabled')).toBe('true');
-      expect(shadowButton?.className).toContain('button-cta--disabled');
+  describe('No Disabled State (philosophy exclusion)', () => {
+    // DesignerPunk does not support disabled states: if an action is
+    // unavailable, the component should not be rendered. state_disabled was
+    // removed from Button-CTA per the 2026-07-15 adjudication; these tests
+    // guard against the disabled state resurfacing.
+
+    it('should declare state_disabled under excludes (not contracts) in contracts.yaml', () => {
+      const fs = require('fs');
+      const path = require('path');
+      const contractsContent = fs.readFileSync(
+        path.join(__dirname, '../contracts.yaml'),
+        'utf-8'
+      );
+
+      const contractsSection = contractsContent.split(/^excludes:/m)[0];
+      const excludesSection = contractsContent.split(/^excludes:/m)[1] ?? '';
+      expect(contractsSection).not.toContain('state_disabled');
+      expect(excludesSection).toContain('state_disabled');
     });
-    
-    it('should not have disabled attributes when disabled is false', () => {
-      // Requirement: Enabled button is interactive
-      const button = createButton({ label: 'Enabled Button', disabled: false });
-      
-      const shadowButton = button.shadowRoot?.querySelector('button');
-      expect(shadowButton?.hasAttribute('disabled')).toBe(false);
-      expect(shadowButton?.getAttribute('aria-disabled')).toBe('false');
-      expect(shadowButton?.className).not.toContain('button-cta--disabled');
+
+    it('should not expose a disabled property or observe a disabled attribute', () => {
+      expect(ButtonCTA.observedAttributes).not.toContain('disabled');
+
+      const button = createButton({ label: 'Button' });
+      expect('disabled' in button).toBe(false);
     });
-    
-    it('should prevent press event when disabled', () => {
-      // Requirement: Disabled button doesn't trigger onPress
-      const button = createButton({ label: 'Disabled Button', disabled: true });
-      
+
+    it('should ignore a disabled attribute set by consumers', () => {
+      const button = createButton({ label: 'Button' });
+      button.setAttribute('disabled', '');
+
       let pressCount = 0;
       button.addEventListener('press', () => {
         pressCount++;
       });
-      
+
       const shadowButton = button.shadowRoot?.querySelector('button');
+      expect(shadowButton?.hasAttribute('disabled')).toBe(false);
+      expect(shadowButton?.className).not.toContain('button-cta--disabled');
+
       shadowButton?.click();
-      
-      expect(pressCount).toBe(0);
+      expect(pressCount).toBe(1);
     });
   });
   
@@ -407,21 +413,6 @@ describe('Button-CTA Component Rendering', () => {
       shadowButton?.click();
       
       expect(pressCount).toBe(1);
-    });
-    
-    it('should NOT call onPress when button disabled', () => {
-      // Requirement 15.1: Disabled button doesn't trigger onPress
-      const button = createButton({ label: 'Disabled Button', disabled: true });
-      
-      let pressCount = 0;
-      button.addEventListener('press', () => {
-        pressCount++;
-      });
-      
-      const shadowButton = button.shadowRoot?.querySelector('button');
-      shadowButton?.click();
-      
-      expect(pressCount).toBe(0);
     });
     
     it('should receive focus via Tab key', () => {
@@ -647,19 +638,6 @@ describe('Button-CTA Component Rendering', () => {
       expect(shadowButton?.getAttribute('role')).toBe('button');
       expect(shadowButton?.getAttribute('aria-label')).toBe('Accessible Button');
       expect(shadowButton?.getAttribute('type')).toBe('button');
-      expect(shadowButton?.getAttribute('aria-disabled')).toBe('false');
-    });
-    
-    it('should have proper ARIA attributes when disabled', () => {
-      // Requirement 12.6: Disabled button has correct ARIA attributes
-      const button = createButton({ label: 'Disabled Button', disabled: true });
-      
-      const shadowButton = button.shadowRoot?.querySelector('button');
-      
-      // Verify disabled ARIA attributes
-      expect(shadowButton?.getAttribute('role')).toBe('button');
-      expect(shadowButton?.getAttribute('aria-disabled')).toBe('true');
-      expect(shadowButton?.hasAttribute('disabled')).toBe(true);
     });
     
     it('should support keyboard navigation with Enter key', () => {
@@ -716,37 +694,5 @@ describe('Button-CTA Component Rendering', () => {
       expect(pressCount).toBe(1);
     });
     
-    it('should not activate on keyboard when disabled', () => {
-      // Requirement 15.4: Disabled button doesn't respond to keyboard
-      const button = createButton({ label: 'Disabled Keyboard', disabled: true });
-      
-      let pressCount = 0;
-      button.addEventListener('press', () => {
-        pressCount++;
-      });
-      
-      const shadowButton = button.shadowRoot?.querySelector('button');
-      shadowButton?.focus();
-      
-      // Try Enter key
-      const enterEvent = new KeyboardEvent('keydown', {
-        key: 'Enter',
-        code: 'Enter',
-        bubbles: true,
-        cancelable: true
-      });
-      shadowButton?.dispatchEvent(enterEvent);
-      
-      // Try Space key
-      const spaceEvent = new KeyboardEvent('keydown', {
-        key: ' ',
-        code: 'Space',
-        bubbles: true,
-        cancelable: true
-      });
-      shadowButton?.dispatchEvent(spaceEvent);
-      
-      expect(pressCount).toBe(0);
-    });
   });
 });

--- a/src/components/core/Button-CTA/__tests__/setup.test.ts
+++ b/src/components/core/Button-CTA/__tests__/setup.test.ts
@@ -123,7 +123,6 @@ describe('Button-CTA Test Infrastructure Setup', () => {
         buttonVariant: 'secondary',
         icon: 'arrow-right',
         noWrap: true,
-        disabled: false,
         testID: 'test-button'
       });
       
@@ -132,7 +131,6 @@ describe('Button-CTA Test Infrastructure Setup', () => {
       expect(button.buttonVariant).toBe('secondary');
       expect(button.icon).toBe('arrow-right');
       expect(button.noWrap).toBe(true);
-      expect(button.disabled).toBe(false);
       expect(button.testID).toBe('test-button');
     });
     

--- a/src/components/core/Button-CTA/__tests__/test-utils.ts
+++ b/src/components/core/Button-CTA/__tests__/test-utils.ts
@@ -96,7 +96,6 @@ export async function createButtonCTA(props: {
   buttonVariant?: 'primary' | 'secondary' | 'tertiary';
   icon?: string;
   noWrap?: boolean;
-  disabled?: boolean;
   testID?: string;
 }): Promise<ButtonCTA> {
   registerButtonCTA();
@@ -109,7 +108,6 @@ export async function createButtonCTA(props: {
   if (props.buttonVariant) button.buttonVariant = props.buttonVariant;
   if (props.icon) button.icon = props.icon;
   if (props.noWrap !== undefined) button.noWrap = props.noWrap;
-  if (props.disabled !== undefined) button.disabled = props.disabled;
   if (props.testID) button.testID = props.testID;
   
   // Append to document to trigger rendering

--- a/src/components/core/Button-CTA/contracts.yaml
+++ b/src/components/core/Button-CTA/contracts.yaml
@@ -9,17 +9,14 @@ contracts:
     behavior: |
       Component can receive focus via Tab key navigation.
       Focus state is visually indicated with a focus ring.
-      Focus is managed appropriately when disabled state changes.
     wcag: "2.1.1 Keyboard"
     platforms: [web, ios, android]
     validation:
       - Tab key moves focus to button
       - Focus state is visually distinct with focus ring
       - Focus ring meets 3:1 contrast ratio
-      - Disabled buttons are not focusable
     test_approach: |
       - Render button, press Tab, verify focus
-      - Set disabled=true, verify not focusable
     required: true
 
   interaction_pressable:
@@ -27,7 +24,7 @@ contracts:
     description: Responds to press/click events
     behavior: |
       Component responds to click, tap, Enter key, and Space key.
-      Press triggers the onPress callback when not disabled.
+      Press triggers the onPress callback.
       Platform-appropriate feedback is provided during press.
     wcag: "2.1.1 Keyboard"
     platforms: [web, ios, android]
@@ -35,11 +32,9 @@ contracts:
       - Click/tap triggers onPress callback
       - Enter key triggers onPress callback
       - Space key triggers onPress callback
-      - onPress not called when disabled
     test_approach: |
       - Click button, verify onPress called
       - Focus and press Enter, verify onPress called
-      - Set disabled, click, verify onPress not called
     required: true
 
   interaction_hover:
@@ -56,10 +51,8 @@ contracts:
       - Background color darkens on mouse enter (ΔL 0.02–0.05)
       - Background color reverts on mouse leave
       - Chroma unchanged between rest and hover states
-      - Hover state not shown when disabled
     test_approach: |
       - Simulate hover, verify background change
-      - Set disabled, simulate hover, verify no change
     required: true
 
   interaction_pressed:
@@ -76,29 +69,8 @@ contracts:
       - Visual feedback shown during press (ΔL 0.05–0.10)
       - Pressed state is perceptibly stronger than hover
       - Platform-appropriate animation/effect applied
-      - Pressed state not shown when disabled
     test_approach: |
       - Simulate press, verify visual feedback
-    required: true
-
-  state_disabled:
-    category: state
-    description: Prevents interaction when disabled
-    behavior: |
-      When disabled, component cannot receive focus, cannot be clicked/tapped,
-      appears visually muted via chroma reduction (OKLCH ΔC ≥0.03 desaturation),
-      shows cursor: not-allowed (web), and communicates disabled state to
-      assistive technology.
-    wcag: "4.1.2 Name, Role, Value"
-    platforms: [web, ios, android]
-    validation:
-      - Button cannot receive focus when disabled
-      - onPress not called when disabled
-      - Visual styling indicates disabled state (chroma reduced ≥0.03)
-      - aria-disabled="true" set (web)
-    test_approach: |
-      - Set disabled=true, verify not focusable
-      - Verify aria-disabled attribute (web)
     required: true
 
   state_loading:
@@ -138,3 +110,8 @@ contracts:
       - Tab to button, verify focus ring visible
       - Test in each variant
     required: true
+
+excludes:
+  state_disabled:
+    reason: "DesignerPunk does not support disabled states for usability and accessibility reasons. If an action is unavailable, the component should not be rendered."
+    category: state

--- a/src/components/core/Button-CTA/examples/BasicUsage.html
+++ b/src/components/core/Button-CTA/examples/BasicUsage.html
@@ -99,12 +99,8 @@
   </div>
   
   <div class="example-section">
-    <h2>Example 4: Disabled Button</h2>
-    <p>Button in disabled state that cannot be interacted with.</p>
-    <div class="button-container">
-      <button-cta id="disabled-btn" label="Submit" disabled></button-cta>
-    </div>
-    <div class="output" id="disabled-output">This button is disabled and won't respond to clicks.</div>
+    <h2>Example 4: Unavailable Actions</h2>
+    <p>DesignerPunk does not support disabled states. If an action is unavailable, the button should not be rendered. For in-flight async operations, use the loading state instead.</p>
   </div>
   
   <script type="module">
@@ -131,14 +127,6 @@
     handlerBtn.addEventListener('press', () => {
       handlerOutput.textContent = `Form submitted at ${new Date().toLocaleTimeString()}`;
       // In a real app, you would validate and submit form data here
-    });
-    
-    // Example 4: Disabled button
-    const disabledBtn = document.getElementById('disabled-btn');
-    const disabledOutput = document.getElementById('disabled-output');
-    disabledBtn.addEventListener('press', () => {
-      // This will never be called because button is disabled
-      disabledOutput.textContent = 'This should never appear!';
     });
   </script>
 </body>

--- a/src/components/core/Button-CTA/examples/BasicUsage.tsx
+++ b/src/components/core/Button-CTA/examples/BasicUsage.tsx
@@ -22,7 +22,6 @@ import { ButtonCTA } from '../platforms/web/ButtonCTA.web';
  * - size: 'medium' (48px height)
  * - variant: 'primary' (filled background with primary color)
  * - noWrap: false (text wraps if needed)
- * - disabled: false (interactive)
  * 
  * @example
  * ```html
@@ -79,7 +78,6 @@ export function customLabelButton(): void {
  * 
  * The 'press' event:
  * - Bubbles up through the DOM
- * - Is not called when button is disabled
  * - Works with click, tap, Enter key, and Space key
  * - Provides originalEvent in event.detail for advanced use cases
  * 
@@ -111,55 +109,37 @@ export function buttonWithHandler(): void {
 }
 
 /**
- * Example 4: Disabled Button
+ * Example 4: Unavailable Actions (no disabled state)
  * 
- * Demonstrates how to disable a button to prevent user interaction.
- * Disabled buttons are commonly used during form submission, when prerequisites
- * aren't met, or when an action is temporarily unavailable.
+ * DesignerPunk does not support disabled states for usability and
+ * accessibility reasons. If an action is unavailable, the component
+ * should not be rendered.
  * 
- * Disabled button behavior:
- * - Not keyboard focusable (skipped in Tab order)
- * - Does not respond to clicks or keyboard activation
- * - Visual styling indicates non-interactive state
- * - Screen readers announce disabled state
- * - onPress handler is not called
- * 
- * Common use cases:
- * - Form submission in progress
- * - Required fields not filled
- * - User lacks permissions
- * - Action temporarily unavailable
- * 
- * @example
- * ```html
- * <button-cta label="Submit" disabled></button-cta>
- * ```
+ * For in-flight async operations (e.g. form submission), use the loading
+ * state instead of disabling the button. For actions the user cannot take
+ * yet, keep the button interactive and validate on press, or do not render
+ * the button at all.
  * 
  * @example
  * ```typescript
- * // Conditional disable based on form state
- * const button = document.createElement('button-cta') as ButtonCTA;
- * button.label = 'Submit';
- * button.disabled = isSubmitting || !isFormValid;
+ * // Conditionally render instead of disabling
+ * if (userCanSubmit) {
+ *   const button = document.createElement('button-cta') as ButtonCTA;
+ *   button.label = 'Submit';
+ *   button.addEventListener('press', handleSubmit);
+ *   document.body.appendChild(button);
+ * }
  * ```
  */
-export function disabledButton(): void {
+export function conditionallyRenderedButton(): void {
   const button = document.createElement('button-cta') as ButtonCTA;
   button.label = 'Submit';
-  button.disabled = true; // Button is non-interactive
   
-  // This handler will NOT be called when button is disabled
   button.addEventListener('press', () => {
-    console.log('This will not be logged when button is disabled');
+    console.log('Submitted');
   });
   
   document.body.appendChild(button);
-  
-  // Example: Enable button after 3 seconds (simulating async operation)
-  setTimeout(() => {
-    button.disabled = false;
-    console.log('Button is now enabled');
-  }, 3000);
 }
 
 /**
@@ -201,13 +181,6 @@ export function renderAllBasicExamples(): void {
     alert('Form submitted successfully!');
   });
   container.appendChild(handlerBtn);
-  
-  // Example 4: Disabled
-  const disabledBtn = document.createElement('button-cta') as ButtonCTA;
-  disabledBtn.label = 'Disabled Button';
-  disabledBtn.disabled = true;
-  disabledBtn.addEventListener('press', () => console.log('This will not log'));
-  container.appendChild(disabledBtn);
   
   // Add container to document
   document.body.appendChild(container);

--- a/src/components/core/Button-CTA/platforms/android/ButtonCTA.android.kt
+++ b/src/components/core/Button-CTA/platforms/android/ButtonCTA.android.kt
@@ -11,7 +11,7 @@
  * while maintaining API consistency with web and iOS platforms.
  * 
  * Uses theme-aware blend utilities (Color extensions with Compose MaterialTheme) for
- * state colors (hover, pressed, disabled, icon) instead of opacity or Material ripple
+ * state colors (hover, pressed, icon) instead of opacity or Material ripple
  * workarounds. This ensures cross-platform consistency with Web and iOS implementations.
  * 
  * Part of the DesignerPunk CTA Button Component system.
@@ -42,11 +42,10 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.designerpunk.tokens.DesignTokens
 // Import theme-aware blend utilities (Color extension functions from ThemeAwareBlendUtilities.android.kt)
-// These provide semantic blend methods: hoverBlend(), pressedBlend(), disabledBlend(), iconBlend()
+// These provide semantic blend methods: hoverBlend(), pressedBlend(), iconBlend()
 // @see Requirements: 11.1, 11.2, 11.3 - Theme-aware utilities
 import com.designerpunk.tokens.hoverBlend
 import com.designerpunk.tokens.pressedBlend
-import com.designerpunk.tokens.disabledBlend
 import com.designerpunk.tokens.iconBlend
 
 /**
@@ -88,8 +87,8 @@ enum class ButtonCTAStyle {
  * three size variants, three visual styles, optional leading icons, and
  * theme-aware blend utilities for state colors.
  * 
- * Uses theme-aware Color extensions (hoverBlend(), pressedBlend(), disabledBlend(),
- * iconBlend()) with Compose MaterialTheme for automatic theme color updates.
+ * Uses theme-aware Color extensions (hoverBlend(), pressedBlend(), iconBlend())
+ * with Compose MaterialTheme for automatic theme color updates.
  * 
  * Usage:
  * ```kotlin
@@ -120,7 +119,7 @@ enum class ButtonCTAStyle {
  * Requirements:
  * - 1.1-1.7: Size variants (small: 40dp, medium: 48dp, large: 56dp)
  * - 2.1-2.4: Visual styles (primary, secondary, tertiary)
- * - 7.1-7.4: Blend utility state colors (hover, pressed, disabled, icon)
+ * - 7.1-7.4: Blend utility state colors (hover, pressed, icon)
  * - 8.1-8.6: Icon support with leading position
  * - 11.1-11.3: Theme-aware blend utilities with Compose MaterialTheme
  * - 13.1-13.4: Touch target accessibility (44dp minimum)
@@ -132,7 +131,6 @@ enum class ButtonCTAStyle {
  * @param noWrap Prevent text wrapping (default: false)
  * @param onPress Click/tap handler (required)
  * @param testID Optional test identifier
- * @param disabled Optional disabled state (default: false)
  */
 @Composable
 fun ButtonCTA(
@@ -142,8 +140,7 @@ fun ButtonCTA(
     icon: String? = null,
     noWrap: Boolean = false,
     onPress: () -> Unit,
-    testID: String? = null,
-    disabled: Boolean = false
+    testID: String? = null
 ) {
     val theme = LocalDPTheme.current
     // Remember interaction source for tracking pressed state
@@ -154,7 +151,7 @@ fun ButtonCTA(
     val sizeConfig = getButtonCTASizeConfig(size)
     
     // Get style-based configuration with blend utilities
-    val styleConfig = getButtonCTAStyleConfig(style, isPressed, disabled)
+    val styleConfig = getButtonCTAStyleConfig(style, isPressed)
     
     // Use Surface with clickable modifier (no ripple indication for cross-platform consistency)
     Surface(
@@ -169,7 +166,6 @@ fun ButtonCTA(
             // Apply clickable without ripple indication (blend colors handle state feedback)
             .clickable(
                 onClick = onPress,
-                enabled = !disabled,
                 interactionSource = interactionSource,
                 indication = null // No ripple - using blend colors for state feedback
             ),
@@ -316,7 +312,7 @@ private fun getButtonCTASizeConfig(size: ButtonCTASize): ButtonCTASizeConfig {
  * Style configuration data class
  * 
  * Encapsulates all style-related properties for a button visual style.
- * Uses blend utilities for state colors (pressed, disabled, icon optical balance).
+ * Uses blend utilities for state colors (pressed, icon optical balance).
  * 
  * @property backgroundColor Background color (includes state-based blend)
  * @property textColor Text color
@@ -338,36 +334,32 @@ private data class ButtonCTAStyleConfig(
  * Returns configuration object with all style-related properties based on
  * semantic color tokens and theme-aware blend utilities for state colors.
  * 
- * Uses theme-aware Color extensions (hoverBlend(), pressedBlend(), disabledBlend(),
- * iconBlend()) instead of direct blend calculations for cross-platform consistency
+ * Uses theme-aware Color extensions (hoverBlend(), pressedBlend(), iconBlend())
+ * instead of direct blend calculations for cross-platform consistency
  * with Web and iOS implementations.
  * 
  * Requirements:
  * - 2.1-2.4: Visual styles (primary, secondary, tertiary)
- * - 7.1-7.4: Blend utility state colors (hover, pressed, disabled, icon)
+ * - 7.1-7.4: Blend utility state colors (hover, pressed, icon)
  * - 9.1-9.3: Icon color with optical balance using blend utility
  * - 11.1-11.3: Theme-aware blend utilities with Compose MaterialTheme
  * 
  * @param style Button visual style
  * @param isPressed Whether button is currently pressed
- * @param disabled Whether button is disabled
  * @return Style configuration object with blend-calculated colors
  */
-private fun getButtonCTAStyleConfig(style: ButtonCTAStyle, isPressed: Boolean, disabled: Boolean): ButtonCTAStyleConfig {
+private fun getButtonCTAStyleConfig(style: ButtonCTAStyle, isPressed: Boolean): ButtonCTAStyleConfig {
     // Import semantic color tokens from generated constants
     
     // Calculate state-based background colors using theme-aware blend utilities
     // @see Requirements: 7.1, 7.2, 7.3, 11.1, 11.2, 11.3
     val primaryBgColor = when {
-        // @see Requirements: 7.3 - Disabled uses desaturate(color.action.primary, blend.disabledDesaturate)
-        disabled -> colorActionPrimary.disabledBlend()
         // @see Requirements: 7.2 - Pressed uses darkerBlend(color.action.primary, blend.pressedDarker)
         isPressed -> colorActionPrimary.pressedBlend()
         else -> colorActionPrimary
     }
     
     val secondaryBgColor = when {
-        disabled -> colorBackground
         // @see Requirements: 7.2 - Pressed uses darkerBlend for secondary background
         isPressed -> colorBackground.pressedBlend()
         else -> colorBackground

--- a/src/components/core/Button-CTA/platforms/ios/ButtonCTA.ios.swift
+++ b/src/components/core/Button-CTA/platforms/ios/ButtonCTA.ios.swift
@@ -11,7 +11,7 @@
  * while maintaining API consistency with web and Android platforms.
  * 
  * Uses theme-aware blend utilities (Color extensions with SwiftUI environment) for
- * state colors (hover, pressed, disabled, icon) instead of opacity or scale workarounds.
+ * state colors (hover, pressed, icon) instead of opacity or scale workarounds.
  * This ensures cross-platform consistency with Web and Android implementations.
  * 
  * Part of the DesignerPunk CTA Button Component system.
@@ -23,7 +23,7 @@
 import SwiftUI
 
 // Import theme-aware blend utilities (Color extensions from ThemeAwareBlendUtilities.ios.swift)
-// These provide semantic blend methods: hoverBlend(), pressedBlend(), disabledBlend(), iconBlend()
+// These provide semantic blend methods: hoverBlend(), pressedBlend(), iconBlend()
 // @see Requirements: 11.1, 11.2, 11.3 - Theme-aware utilities
 
 /**
@@ -65,8 +65,8 @@ enum ButtonCTAStyle {
  * three size variants, three visual styles, optional leading icons, and
  * theme-aware blend utilities for state colors.
  * 
- * Uses theme-aware Color extensions (hoverBlend(), pressedBlend(), disabledBlend(),
- * iconBlend()) with SwiftUI environment for automatic theme color updates.
+ * Uses theme-aware Color extensions (hoverBlend(), pressedBlend(), iconBlend())
+ * with SwiftUI environment for automatic theme color updates.
  * 
  * Usage:
  * ```swift
@@ -97,7 +97,7 @@ enum ButtonCTAStyle {
  * Requirements:
  * - 1.1-1.7: Size variants (small: 40px, medium: 48px, large: 56px)
  * - 2.1-2.4: Visual styles (primary, secondary, tertiary)
- * - 7.1-7.4: Blend utility state colors (hover, pressed, disabled, icon)
+ * - 7.1-7.4: Blend utility state colors (hover, pressed, icon)
  * - 8.1-8.6: Icon support with leading position
  * - 11.1-11.3: Theme-aware blend utilities with SwiftUI environment
  * - 13.1-13.4: Touch target accessibility (44px minimum)
@@ -125,10 +125,7 @@ struct ButtonCTA: View {
     
     /// Optional test ID for automated testing
     let testID: String?
-    
-    /// Optional disabled state (default: false)
-    let disabled: Bool
-    
+
     // MARK: - State
     
     /// Tracks pressed state for scale transform animation
@@ -149,7 +146,6 @@ struct ButtonCTA: View {
      *   - noWrap: Prevent text wrapping (default: false)
      *   - onPress: Click/tap handler (required)
      *   - testID: Optional test identifier
-     *   - disabled: Optional disabled state (default: false)
      */
     init(
         label: String,
@@ -158,8 +154,7 @@ struct ButtonCTA: View {
         icon: String? = nil,
         noWrap: Bool = false,
         onPress: @escaping () -> Void,
-        testID: String? = nil,
-        disabled: Bool = false
+        testID: String? = nil
     ) {
         self.label = label
         self.size = size
@@ -168,7 +163,6 @@ struct ButtonCTA: View {
         self.noWrap = noWrap
         self.onPress = onPress
         self.testID = testID
-        self.disabled = disabled
     }
     
     // MARK: - Body
@@ -213,15 +207,12 @@ struct ButtonCTA: View {
         .simultaneousGesture(
             DragGesture(minimumDistance: 0)
                 .onChanged { _ in
-                    if !disabled {
-                        isPressed = true
-                    }
+                    isPressed = true
                 }
                 .onEnded { _ in
                     isPressed = false
                 }
         )
-        .disabled(disabled)
         // Requirement 13.1-13.4, 16.4: Accessibility identifier for testing
         .accessibilityIdentifier(testID ?? "")
         // Requirement 17.4: Respect safe area insets for full-width buttons
@@ -230,14 +221,11 @@ struct ButtonCTA: View {
     
     // MARK: - Blend Color Computed Properties
     
-    /// Current background color based on state (normal, hover, pressed, disabled)
+    /// Current background color based on state (normal, pressed)
     /// Uses theme-aware blend utilities (Color extensions) for cross-platform consistency
-    /// @see Requirements: 7.1, 7.2, 7.3, 11.1, 11.2, 11.3
+    /// @see Requirements: 7.1, 7.2, 11.1, 11.2, 11.3
     private var currentBackgroundColor: Color {
-        if disabled {
-            // @see Requirements: 7.3 - Disabled uses desaturate(color.primary, blend.disabledDesaturate)
-            return disabledBackgroundColor
-        } else if isPressed {
+        if isPressed {
             // @see Requirements: 7.2 - Pressed uses darkerBlend(color.primary, blend.pressedDarker)
             return pressedBackgroundColor
         } else {
@@ -255,20 +243,6 @@ struct ButtonCTA: View {
             return theme.colorActionPrimary.pressedBlend()
         case .secondary:
             return theme.colorStructureCanvas.pressedBlend()
-        case .tertiary:
-            return Color.clear
-        }
-    }
-    
-    /// Disabled state background color using theme-aware blend utility
-    /// Uses disabledBlend() which applies desaturate with blend.disabledDesaturate (12%)
-    /// @see Requirements: 7.3, 11.1, 11.2, 11.3
-    private var disabledBackgroundColor: Color {
-        switch style {
-        case .primary:
-            return theme.colorActionPrimary.disabledBlend()
-        case .secondary:
-            return theme.colorStructureCanvas
         case .tertiary:
             return Color.clear
         }
@@ -532,20 +506,7 @@ struct ButtonCTA_Previews: PreviewProvider {
                     onPress: { print("Confirm pressed") }
                 )
             }
-            
-            Divider()
-            
-            // Disabled state
-            Text("Disabled State")
-                .font(.headline)
-            
-            VStack(spacing: 12) {
-                ButtonCTA(
-                    label: "Disabled Button",
-                    disabled: true,
-                    onPress: { print("Should not print") }
-                )
-            }
+
         }
         .padding()
     }

--- a/src/components/core/Button-CTA/platforms/web/ButtonCTA.web.css
+++ b/src/components/core/Button-CTA/platforms/web/ButtonCTA.web.css
@@ -275,7 +275,7 @@
  * The --_cta-hover-bg custom property is set by the component
  * using darkerBlend(color.primary, blend.hoverDarker) = 8% darker.
  */
-.button-cta--primary:hover:not(:disabled) {
+.button-cta--primary:hover {
   background-color: var(--_cta-hover-bg);
 }
 
@@ -288,7 +288,7 @@
  * The --_cta-pressed-bg custom property is set by the component
  * using darkerBlend(color.primary, blend.pressedDarker) = 12% darker.
  */
-.button-cta--primary:active:not(:disabled) {
+.button-cta--primary:active {
   background-color: var(--_cta-pressed-bg);
 }
 
@@ -316,30 +316,6 @@
  */
 .button-cta:focus:not(:focus-visible) {
   outline: none;
-}
-
-/**
- * Disabled state.
- * 
- * Uses blend utility calculated color (desaturate with blend.disabledDesaturate)
- * instead of opacity workaround for cross-platform consistency.
- * 
- * The --button-disabled-color custom property is set by the component
- * using desaturate(color.primary, blend.disabledDesaturate) = 12% less saturated.
- * 
- * - Cursor changes to not-allowed
- * - Prevents interaction
- * - Maintains color contrast for accessibility
- */
-.button-cta:disabled,
-.button-cta--disabled {
-  cursor: not-allowed;
-  pointer-events: none;
-}
-
-.button-cta--primary:disabled,
-.button-cta--primary.button-cta--disabled {
-  background-color: var(--_cta-disabled-bg);
 }
 
 /* ==========================================================================

--- a/src/components/core/Button-CTA/platforms/web/ButtonCTA.web.ts
+++ b/src/components/core/Button-CTA/platforms/web/ButtonCTA.web.ts
@@ -12,7 +12,7 @@
  * composition pattern as iOS and Android platforms. This ensures cross-platform
  * consistency and single source of truth for icon rendering.
  * 
- * Uses theme-aware blend utilities for state colors (hover, pressed, disabled, icon)
+ * Uses theme-aware blend utilities for state colors (hover, pressed, icon)
  * instead of opacity or filter workarounds. This ensures cross-platform consistency
  * with iOS and Android implementations.
  * 
@@ -86,13 +86,12 @@ function getIconSizeForButton(buttonSize: ButtonSize): IconBaseSize {
  * - Semantic `<button>` element with proper accessibility
  * - Token-based styling via CSS custom properties
  * - Supports text wrapping by default (accessibility-first)
- * - Uses blend utilities for state colors (hover, pressed, disabled, icon)
+ * - Uses blend utilities for state colors (hover, pressed, icon)
  * - WCAG 2.1 AA compliant:
  *   - Keyboard navigation (Tab, Enter, Space)
  *   - Focus indicators with 3:1 contrast ratio
  *   - Color contrast 4.5:1 for all styles
  *   - Screen reader support with ARIA attributes
- *   - Proper disabled state handling
  * 
  * @example
  * ```html
@@ -106,7 +105,6 @@ function getIconSizeForButton(buttonSize: ButtonSize): IconBaseSize {
  *   variant="primary"
  *   icon="arrow-right"
  *   no-wrap="false"
- *   disabled="false"
  *   test-id="submit-button"
  * ></button-cta>
  * ```
@@ -143,7 +141,6 @@ export class ButtonCTA extends HTMLElement {
   // Cached blend colors for state styling
   private _hoverColor: string = '';
   private _pressedColor: string = '';
-  private _disabledColor: string = '';
   private _iconColor: string = '';
   private _iconOpticalBalanceColor: string = '';
   
@@ -153,7 +150,7 @@ export class ButtonCTA extends HTMLElement {
    * When these attributes change, attributeChangedCallback is invoked.
    */
   static get observedAttributes(): string[] {
-    return ['label', 'size', 'variant', 'icon', 'no-wrap', 'disabled', 'test-id'];
+    return ['label', 'size', 'variant', 'icon', 'no-wrap', 'test-id'];
   }
   
   constructor() {
@@ -219,15 +216,14 @@ export class ButtonCTA extends HTMLElement {
    * Calculate blend colors from CSS custom properties.
    * 
    * Reads base colors from CSS custom properties and applies theme-aware blend
-   * utilities to generate state colors (hover, pressed, disabled, icon).
-   * 
+   * utilities to generate state colors (hover, pressed, icon).
+   *
    * Uses getBlendUtilities() factory functions instead of direct blend calculations
    * for cross-platform consistency with iOS and Android implementations.
-   * 
+   *
    * State color mappings:
    * - Hover: darkerBlend(color.action.primary, blend.hoverDarker) - 8% darker
    * - Pressed: darkerBlend(color.action.primary, blend.pressedDarker) - 12% darker
-   * - Disabled: desaturate(color.action.primary, blend.disabledDesaturate) - 12% less saturated
    * - Icon: lighterBlend(color.contrast.onAction, blend.iconLighter) - 8% lighter
    * 
    * @see Requirements: 7.1, 7.2, 7.3, 7.4 - Button-CTA state colors
@@ -258,10 +254,7 @@ export class ButtonCTA extends HTMLElement {
     
     // @see Requirements: 7.2 - Pressed uses darkerBlend(color.action.primary, blend.pressedDarker)
     this._pressedColor = this._blendUtils.pressedColor(primaryColor);
-    
-    // @see Requirements: 7.3 - Disabled uses desaturate(color.action.primary, blend.disabledDesaturate)
-    this._disabledColor = this._blendUtils.disabledColor(primaryColor);
-    
+
     // @see Requirements: 7.4 - Icon uses lighterBlend(color.contrast.onAction, blend.iconLighter)
     // Icon for primary buttons: provides optical balance for icons on primary background
     this._iconColor = this._blendUtils.iconColor(onActionColor);
@@ -372,24 +365,6 @@ export class ButtonCTA extends HTMLElement {
   }
   
   /**
-   * Get the disabled state.
-   */
-  get disabled(): boolean {
-    return this.hasAttribute('disabled');
-  }
-  
-  /**
-   * Set the disabled state.
-   */
-  set disabled(value: boolean) {
-    if (value) {
-      this.setAttribute('disabled', '');
-    } else {
-      this.removeAttribute('disabled');
-    }
-  }
-  
-  /**
    * Get the test ID.
    */
   get testID(): string | null {
@@ -451,17 +426,15 @@ export class ButtonCTA extends HTMLElement {
     const variant = this.buttonVariant;
     const icon = this.icon;
     const noWrap = this.noWrap;
-    const disabled = this.disabled;
     const testID = this.testID;
-    
+
     // Generate class names
     const buttonClasses = [
       'button-cta',
       `button-cta--${size}`,
-      `button-cta--${variant}`,
-      disabled ? 'button-cta--disabled' : ''
-    ].filter(Boolean).join(' ');
-    
+      `button-cta--${variant}`
+    ].join(' ');
+
     // Get icon size for button size variant
     // Icon sizes are type-safe mapped from button size:
     // - Small/Medium: 24px (iconBaseSize100)
@@ -480,7 +453,6 @@ export class ButtonCTA extends HTMLElement {
     const blendColorStyles = `
       --_cta-hover-bg: ${this._hoverColor};
       --_cta-pressed-bg: ${this._pressedColor};
-      --_cta-disabled-bg: ${this._disabledColor};
       --_cta-icon-color: ${this._iconColor};
       --_cta-icon-optical: ${this._iconOpticalBalanceColor};
     `;
@@ -491,11 +463,10 @@ export class ButtonCTA extends HTMLElement {
     // @see Requirements: 8.2, 8.3 (components render correctly with interactivity)
     this._shadowRoot.innerHTML = `
       <style>${buttonStyles}</style>
-      <button 
+      <button
         class="${buttonClasses}"
         type="button"
         role="button"
-        ${disabled ? 'disabled aria-disabled="true"' : 'aria-disabled="false"'}
         ${testIDAttr}
         aria-label="${label}"
         style="${blendColorStyles}"
@@ -536,34 +507,23 @@ export class ButtonCTA extends HTMLElement {
     const variant = this.buttonVariant;
     const icon = this.icon;
     const noWrap = this.noWrap;
-    const disabled = this.disabled;
     const testID = this.testID;
-    
+
     // Get icon size for button size variant
     const iconSize: IconBaseSize = getIconSizeForButton(size);
-    
+
     // ─────────────────────────────────────────────────────────────────
     // Update button element
     // ─────────────────────────────────────────────────────────────────
-    
+
     // Update CSS class (preserves element identity for transitions)
     const buttonClasses = [
       'button-cta',
       `button-cta--${size}`,
-      `button-cta--${variant}`,
-      disabled ? 'button-cta--disabled' : ''
-    ].filter(Boolean).join(' ');
+      `button-cta--${variant}`
+    ].join(' ');
     this._button.className = buttonClasses;
-    
-    // Update disabled state
-    if (disabled) {
-      this._button.setAttribute('disabled', '');
-      this._button.setAttribute('aria-disabled', 'true');
-    } else {
-      this._button.removeAttribute('disabled');
-      this._button.setAttribute('aria-disabled', 'false');
-    }
-    
+
     // Update aria-label
     this._button.setAttribute('aria-label', label);
     
@@ -577,7 +537,6 @@ export class ButtonCTA extends HTMLElement {
     // Update blend color CSS custom properties
     this._button.style.setProperty('--_cta-hover-bg', this._hoverColor);
     this._button.style.setProperty('--_cta-pressed-bg', this._pressedColor);
-    this._button.style.setProperty('--_cta-disabled-bg', this._disabledColor);
     this._button.style.setProperty('--_cta-icon-color', this._iconColor);
     this._button.style.setProperty('--_cta-icon-optical', this._iconOpticalBalanceColor);
     
@@ -638,13 +597,6 @@ export class ButtonCTA extends HTMLElement {
    * Dispatches a custom 'press' event that bubbles up to parent elements.
    */
   private _handleClick = (event: Event): void => {
-    // Don't dispatch if disabled
-    if (this.disabled) {
-      event.preventDefault();
-      event.stopPropagation();
-      return;
-    }
-    
     // Dispatch custom 'press' event
     this.dispatchEvent(new CustomEvent('press', {
       bubbles: true,
@@ -663,11 +615,6 @@ export class ButtonCTA extends HTMLElement {
    * @param event - The keyboard event
    */
   private _handleKeyDown = (event: KeyboardEvent): void => {
-    // Don't handle if disabled
-    if (this.disabled) {
-      return;
-    }
-    
     // Handle Enter and Space keys (WCAG 2.1 AA keyboard navigation)
     if (event.key === 'Enter' || event.key === ' ') {
       event.preventDefault(); // Prevent default space scrolling

--- a/src/components/core/Button-CTA/types.ts
+++ b/src/components/core/Button-CTA/types.ts
@@ -82,7 +82,6 @@ export type ButtonStyle = 'primary' | 'secondary' | 'tertiary';
  *   variant="primary"
  *   icon="arrow-right"
  *   noWrap={false}
- *   disabled={false}
  *   testID="submit-button"
  *   onPress={handleSubmit}
  * />
@@ -197,15 +196,13 @@ export interface ButtonProps {
   
   /**
    * Click/tap handler (required)
-   * 
+   *
    * Callback function invoked when the button is clicked or tapped.
-   * Not called when button is disabled.
-   * 
+   *
    * @remarks
    * - Function signature: `() => void`
-   * - Not invoked when `disabled` is true
    * - Triggered by click, tap, Enter key, or Space key
-   * 
+   *
    * @example
    * ```typescript
    * onPress={() => console.log('Clicked')}
@@ -232,26 +229,11 @@ export interface ButtonProps {
    * ```
    */
   testID?: string;
-  
-  /**
-   * Optional disabled state (default: false)
-   * 
-   * When true, the button is non-interactive and visually indicates
-   * disabled state. The onPress handler is not called when disabled.
-   * 
-   * @defaultValue false
-   * 
-   * @remarks
-   * - Disabled buttons are not keyboard focusable
-   * - Screen readers announce disabled state
-   * - Visual styling indicates non-interactive state
-   * 
-   * @example
-   * ```typescript
-   * disabled={false}  // Interactive (default)
-   * disabled={true}   // Non-interactive
-   * disabled={isSubmitting}  // Conditional disable
-   * ```
-   */
-  disabled?: boolean;
 }
+
+// NO DISABLED STATES
+// DesignerPunk does not support disabled states for usability and
+// accessibility reasons. If an action is unavailable, the component
+// should not be rendered. For in-flight async actions, use the loading
+// state (state_loading) instead.
+// Ruled by Peter 2026-07-15 (Button-CTA disabled-state adjudication).

--- a/token-index/semantics.yaml
+++ b/token-index/semantics.yaml
@@ -1418,8 +1418,7 @@ tokens:
       web: '--blend-disabled-desaturate'
       ios: blendDisabledDesaturate
       android: blend_disabled_desaturate
-    consumers:
-      - Button-CTA
+    consumers: []
   blend.containerHoverDarker:
     category: interaction
     primitiveReferences:


### PR DESCRIPTION
**Spec**: n/a — adjudication routed out of 125-B-classification-map U2 (Peter, 2026-07-14)
**Task**: Button-CTA disabled-state adjudication → ruling: REMOVE (Peter, 2026-07-15)
**Unit**: single-unit fix branch
**Agent**: Lina
**Adjudication record**: `.kiro/issues/button-cta-disabled-state-adjudication.md` (on this branch)
**Validation**: `npx tsc --noEmit` clean; `npm test` 8983/8983; `npm run test:all` 9059/9059 (idle re-run)

## What

Button-CTA was the only component in the corpus with a live `state_disabled` contract; the design philosophy (Spec 038 onward, standardized in Spec 066) is that DesignerPunk does not support disabled states — unavailable actions should not be rendered. Investigation showed the contract was grandfathered from Spec 005 (which pre-dates the philosophy by seven weeks), explicitly deferred by Spec 066, and never adjudicated. Peter ruled **remove**.

- `state_disabled` contract → standardized `excludes` block; disabled references scrubbed from the other contracts
- `disabled` prop removed from types.ts and all three platform implementations (web/iOS/Android)
- Disabled-behavior tests replaced with exclusion-guard tests (contract shape, unobserved attribute, consumer-set `disabled` ignored)
- `css-bundling.test.ts` flipped: browser bundle must ship **no** disabled styles
- Demo page, examples, README, family/governance docs cleaned; token-consumer index regenerated (`blend.disabledDesaturate` now consumer-less)

## Follow-ups (in the adjudication record)

1. **Ada**: `blend.disabledDesaturate` token deprecation decision (calculator capability left intact)
2. **125-B U2**: update the classification-map register note — `state_disabled` may now join the WCAG-floor presence assertion with no carve-out; U1b philosophy-conformance candidate needs no allowlist
3. **Versioning**: removed public prop on the flagship button — breaking-change flag for the next major

🤖 Generated with [Claude Code](https://claude.com/claude-code)