### PR TITLE
Deprecate blend.disabledDesaturate + disabled blend wrappers (no-disabled-states)

### DIFF
--- a/docs/token-system-overview.md
+++ b/docs/token-system-overview.md
@@ -386,7 +386,7 @@ if (validationResult.valid) {
 #### Semantic Blend Tokens
 - **File**: `src/tokens/semantic/BlendTokens.ts`
 - **Description**: Contextual blend amounts for interaction states
-- **Tokens**: blend.hoverDarker, blend.hoverLighter, blend.pressedDarker, blend.focusSaturate, blend.disabledDesaturate, blend.containerHoverDarker, color.icon.opticalBalance
+- **Tokens**: blend.hoverDarker, blend.hoverLighter, blend.pressedDarker, blend.focusSaturate, blend.disabledDesaturate (DEPRECATED 2026-07-15 — no disabled states; removal at next major), blend.containerHoverDarker, color.icon.opticalBalance
 - **Related Guides**:
   - [Blend Tokens Guide](./tokens/blend-tokens.md)
   - [Blend Infrastructure Design](../.kiro/specs/031-blend-infrastructure-implementation/design.md)

--- a/governance/Component-Development-Guide.md
+++ b/governance/Component-Development-Guide.md
@@ -1096,7 +1096,6 @@ class MyComponent extends HTMLElement {
     // Calculate state colors
     this._hoverColor = blendUtils.hoverColor(primaryColor);      // 8% darker
     this._pressedColor = blendUtils.pressedColor(primaryColor);  // 12% darker
-    this._disabledColor = blendUtils.disabledColor(primaryColor); // 12% desaturated
     this._focusColor = blendUtils.focusColor(primaryColor);      // 8% more saturated
   }
 }
@@ -1145,7 +1144,6 @@ fun MyComponent(primaryColor: Color) {
 | Hover (dark bg) | `blend.hoverLighter` | `lighterBlend(color, 0.08)` | 8% lighter |
 | Pressed | `blend.pressedDarker` | `pressedColor()` | 12% darker |
 | Focus | `blend.focusSaturate` | `focusColor()` | 8% more saturated |
-| Disabled | `blend.disabledDesaturate` | `disabledColor()` | 12% desaturated |
 | Container hover | `blend.containerHoverDarker` | `darkerBlend(color, 0.04)` | 4% darker |
 | Icon optical | `color.icon.opticalBalance` | `iconColor()` | 8% lighter |
 

--- a/governance/Component-Family-Form-Inputs.md
+++ b/governance/Component-Family-Form-Inputs.md
@@ -908,7 +908,6 @@ Components in the Form Inputs family consume these design tokens:
 | Accessibility | `accessibility.focus.color` | Focus ring color |
 | Icon | `icon.size100` | Icon size |
 | Blend | `blend.focusSaturate` | Focus state saturation |
-| Blend | `blend.disabledDesaturate` | Disabled state desaturation |
 
 #### Checkbox Tokens
 

--- a/governance/Token-Family-Blend.md
+++ b/governance/Token-Family-Blend.md
@@ -3,13 +3,13 @@ id: token-family-blend
 inclusion: manual
 name: Token-Family-Blend
 aliases: blend token work
-description: Blend token family — color modification utilities (darken, lighten, saturate, desaturate) producing opaque colors. Load when working with hover/pressed/disabled/focus color states or theme-aware color blending.
+description: Blend token family — color modification utilities (darken, lighten, saturate, desaturate) producing opaque colors. Load when working with hover/pressed/focus color states or theme-aware color blending.
 ---
 
 # Blend Tokens Guide
 
 **Date**: 2025-12-29
-**Last Reviewed**: 2026-05-06
+**Last Reviewed**: 2026-07-15
 **Purpose**: Complete reference for blend tokens with utility functions and theme-aware patterns
 **Organization**: token-documentation
 **Scope**: cross-project
@@ -27,7 +27,9 @@ The DesignerPunk blend token system provides a mathematically consistent foundat
 - **Opaque Color Results**: Blend operations produce new opaque colors, not transparent overlays
 - **Cross-Platform Consistency**: Same blend calculations produce identical results (±1 RGB) across Web, iOS, and Android
 - **Theme-Aware**: Blend utilities work correctly with both light and dark themes
-- **Semantic Meaning**: Semantic blend tokens express design intent (hover, pressed, disabled, focus)
+- **Semantic Meaning**: Semantic blend tokens express design intent (hover, pressed, focus)
+
+> **Deprecation note (2026-07-15)**: `blend.disabledDesaturate` and the `disabledColor()`/`disabledBlend()` convenience wrappers are **DEPRECATED**. DesignerPunk does not support disabled states (Button-CTA disabled-state adjudication, ruled REMOVE — the philosophy holds corpus-wide): if an action is unavailable, do not render the component. The deprecated surfaces remain for backward compatibility and are scheduled for removal in the next major version of `@3fn/core`. The generic `desaturate()` utilities are NOT deprecated.
 
 ---
 
@@ -54,7 +56,7 @@ Blend tokens can be applied in four directions:
 | `darker` | Overlay black at specified opacity | Hover/pressed states on light backgrounds |
 | `lighter` | Overlay white at specified opacity | Hover/pressed states on dark backgrounds, icon optical balance |
 | `saturate` | Increase color saturation in HSL space | Focus states, emphasis |
-| `desaturate` | Decrease color saturation in HSL space | Disabled states |
+| `desaturate` | Decrease color saturation in HSL space | Muted, de-emphasized colors |
 
 ---
 
@@ -68,7 +70,7 @@ Semantic blend tokens provide contextual meaning for common color modification u
 | `blend.hoverLighter` | blend200 | lighter | 8% | Hover feedback on dark backgrounds |
 | `blend.pressedDarker` | blend300 | darker | 12% | Pressed state feedback |
 | `blend.focusSaturate` | blend200 | saturate | 8% | Focus state with increased saturation |
-| `blend.disabledDesaturate` | blend300 | desaturate | 12% | Disabled state with decreased saturation |
+| `blend.disabledDesaturate` | blend300 | desaturate | 12% | **DEPRECATED 2026-07-15** — no disabled states in DesignerPunk; removal at next major |
 | `blend.containerHoverDarker` | blend100 | darker | 4% | Subtle container/surface hover |
 | `color.icon.opticalBalance` | blend200 | lighter | 8% | Icon optical weight compensation |
 
@@ -107,7 +109,7 @@ import {
 | `hoverColor(baseColor)` | darkerBlend | 8% (blend200) |
 | `pressedColor(baseColor)` | darkerBlend | 12% (blend300) |
 | `focusColor(baseColor)` | saturate | 8% (blend200) |
-| `disabledColor(baseColor)` | desaturate | 12% (blend300) |
+| `disabledColor(baseColor)` | desaturate | **DEPRECATED 2026-07-15** — removal at next major |
 | `iconColor(baseColor)` | lighterBlend | 8% (blend200) |
 
 **Usage Example**:
@@ -125,7 +127,6 @@ class ButtonCTA extends HTMLElement {
     // Calculate state colors
     this._hoverColor = blendUtils.hoverColor(primaryColor);
     this._pressedColor = blendUtils.pressedColor(primaryColor);
-    this._disabledColor = blendUtils.disabledColor(primaryColor);
   }
 }
 ```
@@ -168,7 +169,7 @@ extension Color {
     /// Focus state color (8% more saturated)
     func focusBlend() -> Color
     
-    /// Disabled state color (12% less saturated)
+    /// DEPRECATED 2026-07-15 — no disabled states in DesignerPunk; removal at next major
     func disabledBlend() -> Color
     
     /// Icon optical balance (8% lighter)
@@ -189,7 +190,6 @@ struct ButtonCTA: View {
         .background(isPressed ? primaryColor.pressedBlend() : 
                     isHovered ? primaryColor.hoverBlend() : 
                     primaryColor)
-        .foregroundColor(isDisabled ? primaryColor.disabledBlend() : primaryColor)
     }
 }
 ```
@@ -216,7 +216,7 @@ fun Color.desaturate(amount: Float): Color
 fun Color.hoverBlend(): Color    // 8% darker
 fun Color.pressedBlend(): Color  // 12% darker
 fun Color.focusBlend(): Color    // 8% more saturated
-fun Color.disabledBlend(): Color // 12% less saturated
+fun Color.disabledBlend(): Color // DEPRECATED 2026-07-15 — removal at next major
 fun Color.iconBlend(): Color     // 8% lighter
 ```
 
@@ -266,7 +266,6 @@ class ButtonCTA extends HTMLElement {
     const blendUtils = getBlendUtilities();
     this._hoverColor = blendUtils.hoverColor(primaryColor);
     this._pressedColor = blendUtils.pressedColor(primaryColor);
-    this._disabledColor = blendUtils.disabledColor(primaryColor);
     this._iconColor = blendUtils.iconColor(onPrimaryColor);
   }
   
@@ -348,7 +347,6 @@ const iconStyle = { filter: 'brightness(1.08)' };
 const blendUtils = getBlendUtilities();
 const hoverColor = blendUtils.hoverColor(primaryColor);      // darkerBlend 8%
 const pressedColor = blendUtils.pressedColor(primaryColor);  // darkerBlend 12%
-const disabledColor = blendUtils.disabledColor(primaryColor); // desaturate 12%
 const iconColor = blendUtils.iconColor(onPrimaryColor);      // lighterBlend 8%
 ```
 
@@ -357,7 +355,6 @@ const iconColor = blendUtils.iconColor(onPrimaryColor);      // lighterBlend 8%
 ```typescript
 const blendUtils = getBlendUtilities();
 const focusColor = blendUtils.focusColor(primaryColor);      // saturate 8%
-const disabledColor = blendUtils.disabledColor(primaryColor); // desaturate 12%
 ```
 
 ### Container Component
@@ -414,7 +411,6 @@ Use semantic blend tokens for standard interaction states:
 | Hover (dark bg) | `blend.hoverLighter` | `lighterBlend(color, 0.08)` |
 | Pressed | `blend.pressedDarker` | `pressedColor()` |
 | Focus | `blend.focusSaturate` | `focusColor()` |
-| Disabled | `blend.disabledDesaturate` | `disabledColor()` |
 | Container hover | `blend.containerHoverDarker` | `darkerBlend(color, 0.04)` |
 | Icon optical | `color.icon.opticalBalance` | `iconColor()` |
 
@@ -432,6 +428,13 @@ const emphasisColor = blendUtils.darkerBlend(color, 0.16); // blend400 = 16%
 ```
 
 ### Anti-Patterns to Avoid
+
+**❌ Don't style disabled states**:
+```typescript
+// WRONG: DesignerPunk does not support disabled states (adjudicated 2026-07-15).
+// If an action is unavailable, do not render the component.
+const disabledColor = blendUtils.disabledColor(primaryColor);
+```
 
 **❌ Don't use opacity for state colors**:
 ```typescript
@@ -481,7 +484,7 @@ blend500 = base × 5 = 0.04 × 5 = 0.20 (20%)
 | blend.hoverLighter | blend200 | 8% |
 | blend.pressedDarker | blend300 | 12% |
 | blend.focusSaturate | blend200 | 8% |
-| blend.disabledDesaturate | blend300 | 12% |
+| blend.disabledDesaturate (deprecated) | blend300 | 12% |
 | blend.containerHoverDarker | blend100 | 4% |
 | color.icon.opticalBalance | blend200 | 8% |
 

--- a/src/blend/OklchBlendCalculator.ts
+++ b/src/blend/OklchBlendCalculator.ts
@@ -17,6 +17,8 @@
 
 import type { Oklch } from '../color/OklchConverter';
 
+// 'disabled' is deprecated calculator capability: DesignerPunk supports no disabled
+// states (adjudicated 2026-07-15) — no component may use it; removal at next major.
 export type InteractionState = 'hover' | 'pressed' | 'focused' | 'disabled';
 
 /** Thresholds for interaction state blends. */
@@ -24,6 +26,7 @@ export const INTERACTION_THRESHOLDS = {
   hover:    { deltaL: { min: 0.02, max: 0.05 }, deltaC: 0 },
   pressed:  { deltaL: { min: 0.05, max: 0.10 }, deltaC: 0 },
   focused:  { deltaL: 0, deltaC: { min: 0.02 } },
+  // deprecated 2026-07-15 (no-disabled-states philosophy) — removal at next major
   disabled: { deltaL: 0, deltaC: { min: 0.03 } },
 } as const;
 

--- a/src/blend/ThemeAwareBlendUtilities.android.kt
+++ b/src/blend/ThemeAwareBlendUtilities.android.kt
@@ -37,6 +37,7 @@ object BlendTokenValues {
     const val focusSaturate: Float = 0.08f
     
     /** Disabled state desaturation - blend300 (12%) */
+    @Deprecated("DesignerPunk does not support disabled states (adjudicated 2026-07-15). Removal at next major.")
     const val disabledDesaturate: Float = 0.12f
     
     /** Icon optical balance lightening - blend200 (8%) */
@@ -163,6 +164,7 @@ fun Color.focusBlend(): Color {
  *
  * @see Requirements: 11.4 - Theme-aware wrapper functions
  */
+@Deprecated("DesignerPunk does not support disabled states (adjudicated 2026-07-15) — if an action is unavailable, do not render the component. Use desaturate() for non-disabled desaturation. Removal at next major.")
 fun Color.disabledBlend(): Color {
     return this.desaturate(BlendTokenValues.disabledDesaturate)
 }
@@ -280,6 +282,7 @@ object BlendUtilitiesProvider {
      * @param color Base color
      * @return Desaturated color for disabled state
      */
+    @Deprecated("DesignerPunk does not support disabled states (adjudicated 2026-07-15) — if an action is unavailable, do not render the component. Removal at next major.")
     fun disabledColor(color: Color): Color {
         return color.disabledBlend()
     }

--- a/src/blend/ThemeAwareBlendUtilities.ios.swift
+++ b/src/blend/ThemeAwareBlendUtilities.ios.swift
@@ -28,6 +28,7 @@ public struct BlendTokenValues {
     public static let focusSaturate: Double = 0.08
     
     /// Disabled state desaturation - blend300 (12%)
+    @available(*, deprecated, message: "DesignerPunk does not support disabled states (adjudicated 2026-07-15). Removal at next major.")
     public static let disabledDesaturate: Double = 0.12
     
     /// Icon optical balance lightening - blend200 (8%)
@@ -172,6 +173,7 @@ extension Color {
     /// ```
     ///
     /// @see Requirements: 11.4 - Theme-aware wrapper functions
+    @available(*, deprecated, message: "DesignerPunk does not support disabled states (adjudicated 2026-07-15) — if an action is unavailable, do not render the component. Use desaturate(_:) for non-disabled desaturation. Removal at next major.")
     public func disabledBlend() -> Color {
         return self.desaturate(BlendTokenValues.disabledDesaturate)
     }
@@ -276,6 +278,7 @@ public class BlendUtilitiesProvider {
     /// Calculate disabled color for a given base color
     /// - Parameter color: Base color
     /// - Returns: Desaturated color for disabled state
+    @available(*, deprecated, message: "DesignerPunk does not support disabled states (adjudicated 2026-07-15) — if an action is unavailable, do not render the component. Removal at next major.")
     public func disabledColor(_ color: Color) -> Color {
         return color.disabledBlend()
     }

--- a/src/blend/ThemeAwareBlendUtilities.web.ts
+++ b/src/blend/ThemeAwareBlendUtilities.web.ts
@@ -54,7 +54,11 @@ export const BlendTokenValues = {
   pressedDarker: 0.12,
   /** Focus state saturation increase - blend200 (8%) */
   focusSaturate: 0.08,
-  /** Disabled state desaturation - blend300 (12%) */
+  /**
+   * Disabled state desaturation - blend300 (12%)
+   * @deprecated 2026-07-15 — DesignerPunk does not support disabled states; if an action
+   * is unavailable, do not render the component. Scheduled for removal at the next major.
+   */
   disabledDesaturate: 0.12,
   /** Icon optical balance lightening - blend200 (8%) */
   iconLighter: 0.08
@@ -89,6 +93,9 @@ export interface BlendUtilitiesResult {
    * Calculate disabled color by desaturating the base color
    * @param baseColor - Base color as hex string (e.g., "#A855F7")
    * @returns Desaturated hex color string for disabled state
+   * @deprecated 2026-07-15 — DesignerPunk does not support disabled states; if an action
+   * is unavailable, do not render the component. For non-disabled desaturation, use the
+   * generic desaturate() utility. Scheduled for removal at the next major.
    */
   disabledColor: (baseColor: string) => string;
   
@@ -242,6 +249,7 @@ export function createBlendUtilities(): BlendUtilitiesResult {
     hoverColor: (baseColor: string) => darkerBlend(baseColor, BlendTokenValues.hoverDarker),
     pressedColor: (baseColor: string) => darkerBlend(baseColor, BlendTokenValues.pressedDarker),
     focusColor: (baseColor: string) => saturate(baseColor, BlendTokenValues.focusSaturate),
+    // deprecated 2026-07-15 (no-disabled-states philosophy) — removal at next major
     disabledColor: (baseColor: string) => desaturate(baseColor, BlendTokenValues.disabledDesaturate),
     iconColor: (baseColor: string) => lighterBlend(baseColor, BlendTokenValues.iconLighter),
     

--- a/src/generators/DTCGFormatGenerator.ts
+++ b/src/generators/DTCGFormatGenerator.ts
@@ -724,6 +724,12 @@ export class DTCGFormatGenerator {
       } else if (token.direction === 'lighter') {
         extensions.blendType = 'lighterBlend';
       }
+      // Deprecation metadata (e.g. blend.disabledDesaturate) — lets includeDeprecated: false strip it
+      if (token.deprecated) {
+        extensions.deprecated = true;
+        if (token.deprecatedSince) extensions.deprecatedSince = token.deprecatedSince;
+        if (token.deprecatedReason) extensions.deprecatedReason = token.deprecatedReason;
+      }
 
       group[key] = this.toDTCGToken(aliasValue, 'number', token.description, extensions);
     }

--- a/src/generators/__tests__/DTCGConfigOptions.test.ts
+++ b/src/generators/__tests__/DTCGConfigOptions.test.ts
@@ -200,9 +200,8 @@ describe('DTCGFormatGenerator Configuration Options', () => {
   // -------------------------------------------------------------------------
   describe('includeDeprecated: false', () => {
     it('should exclude tokens marked as deprecated', () => {
-      // Since no tokens currently have deprecated: true in their data,
-      // we verify the infrastructure works by generating with both configs
-      // and confirming the output is identical (no deprecated tokens to strip)
+      // blend.disabledDesaturate is deprecated (2026-07-15, no-disabled-states ruling)
+      // and is currently the only deprecated token in the corpus
       const withDeprecated = new DTCGFormatGenerator({ includeDeprecated: true });
       const withoutDeprecated = new DTCGFormatGenerator({ includeDeprecated: false });
 
@@ -213,10 +212,20 @@ describe('DTCGFormatGenerator Configuration Options', () => {
       expect(outputWith.$schema).toBeDefined();
       expect(outputWithout.$schema).toBeDefined();
 
-      // Since no tokens are currently deprecated, counts should match
+      // includeDeprecated: true keeps the token and carries deprecation metadata
+      const blendWith = outputWith.semanticBlend as Record<string, any>;
+      expect(blendWith['blend.disabledDesaturate']).toBeDefined();
+      expect(blendWith['blend.disabledDesaturate'].$extensions?.designerpunk?.deprecated).toBe(true);
+      expect(blendWith['blend.disabledDesaturate'].$extensions?.designerpunk?.deprecatedSince).toBe('2026-07-15');
+
+      // includeDeprecated: false strips it
+      const blendWithout = outputWithout.semanticBlend as Record<string, any>;
+      expect(blendWithout['blend.disabledDesaturate']).toBeUndefined();
+
+      // Exactly the deprecated token is stripped — nothing else
       const countWith = countAllTokens(outputWith);
       const countWithout = countAllTokens(outputWithout);
-      expect(countWith).toBe(countWithout);
+      expect(countWith).toBe(countWithout + 1);
     });
   });
 });

--- a/src/tokens/semantic/BlendTokens.ts
+++ b/src/tokens/semantic/BlendTokens.ts
@@ -16,7 +16,7 @@
  * - blendHoverLighter: Hover feedback on dark backgrounds (8% lighter)
  * - blendPressedDarker: Pressed state feedback with darkening (12% darker)
  * - blendFocusSaturate: Focus state with increased saturation (8% more saturated)
- * - blendDisabledDesaturate: Disabled state with decreased saturation (12% less saturated)
+ * - blendDisabledDesaturate: DEPRECATED 2026-07-15 — DesignerPunk has no disabled states
  * - blendContainerHoverDarker: Subtle container hover feedback (4% darker)
  * - color.icon.opticalBalance: Icon optical weight compensation (8% lighter)
  * 
@@ -49,6 +49,15 @@ export interface SemanticBlendToken {
 
   /** Detailed description of semantic meaning and appropriate usage */
   description: string;
+
+  /** Token is deprecated — do not use in new work; flows to DTCG $extensions.designerpunk.deprecated */
+  deprecated?: boolean;
+
+  /** ISO date the deprecation took effect */
+  deprecatedSince?: string;
+
+  /** Why the token was deprecated and what to do instead */
+  deprecatedReason?: string;
 }
 
 /**
@@ -111,6 +120,14 @@ export const blendTokens: Record<string, SemanticBlendToken> = {
     description: 'Blend for focus states with saturation increase (8% more saturated) - creates energized, attention-drawing appearance for focused interactive elements'
   },
 
+  /**
+   * @deprecated 2026-07-15 — DesignerPunk does not support disabled states
+   * (Button-CTA disabled-state adjudication, ruled REMOVE; the no-disabled-states
+   * philosophy holds corpus-wide). If an action is unavailable, do not render the
+   * component. Retained for backward compatibility; scheduled for removal in the
+   * next major version of @3fn/core. For non-disabled desaturation needs, use the
+   * generic desaturate utilities with primitive blend tokens.
+   */
   'blend.disabledDesaturate': {
     name: 'blend.disabledDesaturate',
     primitiveReferences: {
@@ -118,8 +135,11 @@ export const blendTokens: Record<string, SemanticBlendToken> = {
     },
     direction: BlendDirection.DESATURATE,
     category: 'interaction',
-    context: 'Disabled state appearance - muted, inactive color',
-    description: 'Blend for disabled states with desaturation (12% less saturated) - creates muted, inactive appearance indicating non-interactive state'
+    context: 'DEPRECATED - disabled states are not supported in DesignerPunk',
+    description: 'DEPRECATED (2026-07-15): DesignerPunk does not support disabled states — if an action is unavailable, do not render the component. Formerly: blend for disabled states with desaturation (12% less saturated). Scheduled for removal in the next major version.',
+    deprecated: true,
+    deprecatedSince: '2026-07-15',
+    deprecatedReason: 'No-disabled-states philosophy holds corpus-wide (Button-CTA adjudication, 2026-07-15). Unavailable actions should not be rendered; state_loading covers in-flight async actions.'
   },
 
   'blend.containerHoverDarker': {
@@ -200,8 +220,9 @@ export function validateBlendTokenCount(): boolean {
  *    → Creates vibrant, attention-drawing appearance for focused elements
  * 
  * 5. Disabled states?
- *    → Use blend.disabledDesaturate (12% less saturated)
- *    → Creates muted appearance indicating non-interactive state
+ *    → DO NOT style disabled states. DesignerPunk does not support disabled states —
+ *      if an action is unavailable, do not render the component (adjudicated 2026-07-15).
+ *    → blend.disabledDesaturate is DEPRECATED and scheduled for removal at the next major.
  * 
  * 6. Large container/surface hover?
  *    → Use blend.containerHoverDarker (4% darker)

--- a/src/validators/StemmaTokenUsageValidator.ts
+++ b/src/validators/StemmaTokenUsageValidator.ts
@@ -294,9 +294,10 @@ export const TOKEN_CATEGORIES = {
     'border.default', 'border.strong',
     'radius.100', 'radius.150', 'radius.200',
   ],
+  // blend.disabledDesaturate removed 2026-07-15: deprecated (no-disabled-states
+  // philosophy) — the validator must not suggest it for new component work
   blend: [
-    'blend.hoverDarker', 'blend.pressedDarker',
-    'blend.disabledDesaturate', 'blend.iconLighter',
+    'blend.hoverDarker', 'blend.pressedDarker', 'blend.iconLighter',
   ],
 };
 


### PR DESCRIPTION
**Spec**: n/a (chore — adjudication follow-up)
**Task**: Button-CTA disabled-state adjudication follow-up #1 — token deprecation (Ada's call, approved by Peter 2026-07-15)
**Agent**: Ada
**Unit**: this chore (single-PR unit)
**Ruling**: `.kiro/issues/button-cta-disabled-state-adjudication.md` (REMOVE, 2026-07-15) · prior PR #82

## What this does (stage 1: deprecate; removal at next major)

- **Token source** (`src/tokens/semantic/BlendTokens.ts`): `blend.disabledDesaturate` marked deprecated (`deprecated: true`, `deprecatedSince: 2026-07-15`, reason); `@deprecated` JSDoc; the AI-agent guidance block now says **do not style disabled states** instead of recommending the token.
- **DTCG export** (`src/generators/DTCGFormatGenerator.ts`): deprecation metadata now flows to `$extensions.designerpunk.deprecated`, so `includeDeprecated: false` strips the token (existing plumbing, first real use). `DTCGConfigOptions.test.ts` updated from its zero-deprecated-tokens assumption to assert exactly this token is stripped.
- **Wrappers deprecated on all 3 platforms**: web `disabledColor` (+ `BlendTokenValues.disabledDesaturate`) via `@deprecated` JSDoc; iOS `disabledBlend()`/`disabledColor(_:)`/`disabledDesaturate` via `@available(*, deprecated, ...)`; Android via `@Deprecated(...)`. Generic `desaturate()` utilities are NOT deprecated — external `@3fn/core/blend` consumers keep the math capability, they lose only the endorsement.
- **Validator** (`StemmaTokenUsageValidator.ts`): token removed from the blend suggestion list — the validator will never suggest it for new component work.
- **Calculator**: `OklchBlendCalculator` `'disabled'` state + threshold annotated as deprecated calculator capability, removal at next major.
- **Docs**: `Token-Family-Blend.md` (deprecation note, tables, examples purged of disabled patterns, new anti-pattern entry, Last Reviewed bumped), `docs/token-system-overview.md` token list annotated.

## ⚠️ Hunks for Lina's review (token-mention rows in her docs)

Mechanical consequence-edits only — no component-architecture judgment: `Component-Development-Guide.md` (disabled row + example line removed from blend guidance), `Component-Family-Form-Inputs.md` (stale `blend.disabledDesaturate` row removed; schema stopped declaring it in Spec 066).

## Known remaining surfaces (deliberately NOT in this PR — chips filed)

1. **Input-Text-Base iOS/Android still call `disabledBlend()`** (live `isDisabled` handling contradicting its own contract exclusion — the 2026-03-01 cleanup was web-only). Lina's cleanup; the platform `@Deprecated`/`@available` attributes here will warn on those call sites until then, which is the intended signal.
2. **`Component-Templates.md` + `Test-Behavioral-Contract-Validation.md`** contain full disabled-state contract templates/checklists — whole-section rewrites for Lina/Thurgood.
3. **Physical removal** of token + wrappers + calculator `'disabled'` state at the next major of `@3fn/core`, alongside the already-flagged Button-CTA `disabled` prop removal.

## Validation

- `npx tsc --noEmit` clean
- `npm test`: 8988/8988 pass (377 suites)
- `npm run test:all`: 9064/9064 pass (381 suites)
- `token-index/` untouched (index shape unchanged; `consumers: []` remains accurate for schema-declared consumption)

🤖 Generated with [Claude Code](https://claude.com/claude-code)