### PR TITLE
Remove Input-Text disabled handling from iOS/Android (no-disabled-states)

### DIFF
--- a/.kiro/issues/input-text-base-disabled-implementation-cleanup.md
+++ b/.kiro/issues/input-text-base-disabled-implementation-cleanup.md
@@ -29,3 +29,25 @@ Removed disabled implementation from web platform files across Input-Text-Base a
 
 Files changed: 8 platform files, 1 schema, 3 contracts, 2 test files.
 Tests: 290/290 suites, 7435/7435 passed.
+
+---
+
+## Follow-up: iOS/Android Cleanup
+
+**Date**: 2026-07-15
+**Resolved by**: Lina
+**Priority**: Low — **RESOLVED**
+
+The 2026-03-01 resolution removed disabled handling from WEB platform files only. The iOS and Android implementations of Input-Text-Base and all 3 children retained live disabled-state handling (`isDisabled` prop, `disabledBlend()` calls, disabled previews), contradicting the `state_disabled` exclusion in contracts.yaml and types.ts (which offers `readOnly` as the alternative and has never had a `disabled` prop).
+
+### Scope
+
+- `InputTextBase.ios.swift` — removed `isDisabled` property, `disabledBlend()` label/border branches, `.disabled(readOnly || isDisabled)` → `.disabled(readOnly)`, field-style `isDisabled` (text color + focus-ring gating), disabled preview, header contract/feature mentions
+- `InputTextBase.android.kt` — removed `disabledBlend` import, `isDisabled` param, `disabledBlend()` label/border branches, focus-ring `!isDisabled` gating, disabled text color, `readOnly = readOnly || isDisabled` → `readOnly`, header mentions
+- Children (Email/Password/PhoneNumber, iOS + Android) — removed inherited `isDisabled` params, pass-throughs, disabled previews; Password also dropped toggle-button disabling (`.disabled(isDisabled)` / `enabled = !isDisabled`)
+- `focusIndicators.test.ts` — assertions updated to the disabled-free focus-ring conditions
+- `form-inputs-contracts.test.ts` — dead `disabled_state` CONTRACT_PATTERNS entry replaced with `DISABLED_EXCLUSION_GUARD_PATTERNS`; new exclusion-guard test asserts no Form Inputs platform implementation contains `isDisabled`, `disabledBlend`, `aria-disabled`, or `cursor: not-allowed` (Spec 066 / Button-CTA pattern)
+
+Note: iOS's `.disabled(readOnly)` is retained — it is SwiftUI's mechanism for the documented `readOnly` prop, not a disabled state.
+
+This completes the component-code prerequisite for Ada's staged deprecation of `blend.disabledDesaturate` and the `disabledBlend()` utility extensions (Button-CTA adjudication follow-up #1, `.kiro/issues/button-cta-disabled-state-adjudication.md`). `token-index/semantics.yaml` shows `consumers: []` for `blend.disabledDesaturate` because the index is schema-derived; these platform-code call sites were invisible to it — now they are gone on all platforms.

--- a/src/__tests__/stemma-system/form-inputs-contracts.test.ts
+++ b/src/__tests__/stemma-system/form-inputs-contracts.test.ts
@@ -93,22 +93,8 @@ const CONTRACT_PATTERNS: Record<string, Record<string, RegExp[]>> = {
       /errorMessage/g,
     ],
   },
-  disabled_state: {
-    web: [
-      /disabled/gi,
-      /aria-disabled/g,
-      /cursor:\s*not-allowed/g,
-    ],
-    ios: [
-      /disabled/gi,
-      /isDisabled/g,
-    ],
-    android: [
-      /enabled/gi,
-      /isEnabled/g,
-      /disabled/gi,
-    ],
-  },
+  // NOTE: disabled_state is a standardized EXCLUSION (no-disabled-states philosophy).
+  // Implementation-level guard patterns live in DISABLED_EXCLUSION_GUARD_PATTERNS below.
   focus_ring: {
     web: [
       /:focus-visible/g,
@@ -140,6 +126,17 @@ const CONTRACT_PATTERNS: Record<string, Record<string, RegExp[]>> = {
     ],
   },
 };
+
+// Disabled-state exclusion guard (no-disabled-states philosophy, Spec 066 / Button-CTA pattern).
+// These patterns must NOT appear in any Form Inputs platform implementation.
+// readOnly is the documented alternative; iOS implements readOnly via SwiftUI
+// .disabled(readOnly), which none of these patterns match.
+const DISABLED_EXCLUSION_GUARD_PATTERNS: RegExp[] = [
+  /isDisabled/,
+  /disabledBlend/,
+  /aria-disabled/,
+  /cursor:\s*not-allowed/,
+];
 
 /**
  * Load component schema
@@ -370,6 +367,28 @@ describe('Form Inputs Family Behavioral Contracts', () => {
         const content = fs.readFileSync(contractsPath, 'utf-8');
         expect(content).toContain('state_disabled');
         expect(content).toContain('excludes');
+      });
+
+      it('no platform implementation should contain disabled-state handling', () => {
+        // Exclusion guard (Spec 066 / Button-CTA pattern): the contracts.yaml
+        // exclusion must hold in code. readOnly is the documented alternative;
+        // iOS implements readOnly via SwiftUI .disabled(readOnly), which is allowed.
+        for (const formComponent of FORM_INPUT_COMPONENTS) {
+          for (const platform of ['web', 'ios', 'android']) {
+            const content = loadPlatformImpl(formComponent, platform);
+            if (!content) continue;
+
+            const violations = DISABLED_EXCLUSION_GUARD_PATTERNS
+              .filter(pattern => pattern.test(content))
+              .map(pattern => pattern.source);
+
+            if (violations.length > 0) {
+              console.log(`${formComponent} (${platform}) disabled-state handling found: ${violations.join(', ')}`);
+            }
+
+            expect(violations).toEqual([]);
+          }
+        }
       });
     });
   });

--- a/src/components/core/Input-Text-Base/__tests__/focusIndicators.test.ts
+++ b/src/components/core/Input-Text-Base/__tests__/focusIndicators.test.ts
@@ -165,8 +165,8 @@ describe('Input-Text-Base Focus Indicators', () => {
       expect(iosComponentContent).toContain('accessibilityFocusWidth');
       expect(iosComponentContent).toContain('accessibilityFocusOffset');
       
-      // Verify focus ring is visible when focused (and not disabled)
-      expect(iosComponentContent).toContain('.opacity(isFocused && !isDisabled ? 1 : 0)');
+      // Verify focus ring is visible when focused
+      expect(iosComponentContent).toContain('.opacity(isFocused ? 1 : 0)');
     });
     
     it('should have focus ring animation that respects reduce motion', () => {
@@ -194,8 +194,8 @@ describe('Input-Text-Base Focus Indicators', () => {
       expect(androidComponentContent).toContain('accessibilityFocusColor');
       expect(androidComponentContent).toContain('accessibilityFocusOffset');
       
-      // Verify focus ring is conditional on focus state (and not disabled)
-      expect(androidComponentContent).toContain('if (isFocused && !isDisabled)');
+      // Verify focus ring is conditional on focus state
+      expect(androidComponentContent).toContain('if (isFocused)');
     });
   });
   
@@ -219,16 +219,15 @@ describe('Input-Text-Base Focus Indicators', () => {
       
       // iOS: Verify focus ring is not conditional on error/success state
       // (it should always show when focused, regardless of validation state)
-      // Note: Focus ring is hidden when disabled (isDisabled check is expected)
       // Find the focus ring section in the InputTextBaseFieldStyle
       const iosFocusRingSection = iosContent.substring(
-        iosContent.indexOf('.opacity(isFocused && !isDisabled ? 1 : 0)'),
-        iosContent.indexOf('.opacity(isFocused && !isDisabled ? 1 : 0)') + 200
+        iosContent.indexOf('.opacity(isFocused ? 1 : 0)'),
+        iosContent.indexOf('.opacity(isFocused ? 1 : 0)') + 200
       );
-      expect(iosFocusRingSection).toContain('.opacity(isFocused && !isDisabled ? 1 : 0)');
-      
-      // Android: Verify focus ring is conditional on focus state (and not disabled)
-      expect(androidContent).toContain('if (isFocused && !isDisabled)');
+      expect(iosFocusRingSection).toContain('.opacity(isFocused ? 1 : 0)');
+
+      // Android: Verify focus ring is conditional on focus state
+      expect(androidContent).toContain('if (isFocused)');
     });
   });
   
@@ -249,10 +248,10 @@ describe('Input-Text-Base Focus Indicators', () => {
       expect(cssContent).toContain(':focus-visible');
       
       // iOS: Uses overlay with opacity based on focus state
-      expect(iosContent).toContain('.opacity(isFocused && !isDisabled ? 1 : 0)');
-      
+      expect(iosContent).toContain('.opacity(isFocused ? 1 : 0)');
+
       // Android: Uses conditional border based on focus state
-      expect(androidContent).toContain('if (isFocused && !isDisabled)');
+      expect(androidContent).toContain('if (isFocused)');
     });
 
     it('should document WCAG 2.4.7 compliance in behavioral contracts', () => {

--- a/src/components/core/Input-Text-Base/platforms/android/InputTextBase.android.kt
+++ b/src/components/core/Input-Text-Base/platforms/android/InputTextBase.android.kt
@@ -15,15 +15,14 @@
  * - Trailing icon support (error, success, info)
  * - Respects reduce motion settings
  * - WCAG 2.1 AA compliant
- * - Uses theme-aware blend utilities for state colors (focus, disabled)
- * 
+ * - Uses theme-aware blend utilities for state colors (focus)
+ *
  * Behavioral Contracts:
  * - focusable: Can receive keyboard focus
  * - float_label_animation: Label animates on focus
  * - validates_on_blur: Validation triggers on blur
  * - error_state_display: Shows error message and styling
  * - success_state_display: Shows success styling
- * - disabled_state: Prevents interaction when disabled
  * - trailing_icon_display: Shows contextual trailing icons
  * - focus_ring: WCAG 2.4.7 focus visible indicator
  * - reduced_motion_support: Respects prefers-reduced-motion
@@ -68,7 +67,6 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import android.provider.Settings
 import com.designerpunk.tokens.focusBlend
-import com.designerpunk.tokens.disabledBlend
 
 /**
  * Input type enumeration
@@ -105,7 +103,6 @@ enum class InputType {
  * @param maxLength Maximum length for input value
  * @param imeAction IME action for keyboard
  * @param keyboardActions Keyboard actions
- * @param isDisabled Disabled state
  */
 @Composable
 fun InputTextBase(
@@ -126,8 +123,7 @@ fun InputTextBase(
     required: Boolean = false,
     maxLength: Int? = null,
     imeAction: ImeAction = ImeAction.Done,
-    keyboardActions: KeyboardActions = KeyboardActions.Default,
-    isDisabled: Boolean = false
+    keyboardActions: KeyboardActions = KeyboardActions.Default
 ) {
     // State
     var isFocused by remember { mutableStateOf(false) }
@@ -192,7 +188,6 @@ fun InputTextBase(
         targetValue = when {
             hasError -> colorFeedbackErrorText
             isSuccess -> colorFeedbackSuccessText
-            isDisabled -> colorActionPrimary.disabledBlend()
             isFocused -> colorActionPrimary.focusBlend()
             else -> colorTextMuted
         },
@@ -204,7 +199,6 @@ fun InputTextBase(
         targetValue = when {
             hasError -> colorFeedbackErrorText
             isSuccess -> colorFeedbackSuccessText
-            isDisabled -> colorActionPrimary.disabledBlend()
             isFocused -> colorActionPrimary.focusBlend()
             else -> colorBorder
         },
@@ -278,7 +272,7 @@ fun InputTextBase(
                         shape = RoundedCornerShape(radius150)
                     )
                     .then(
-                        if (isFocused && !isDisabled) {
+                        if (isFocused) {
                             Modifier.border(
                                 width = accessibilityFocusWidth,
                                 color = accessibilityFocusColor,
@@ -295,7 +289,7 @@ fun InputTextBase(
                     lineHeight = typographyInputLineHeight.sp,
                     fontWeight = FontWeight(typographyInputFontWeight),
                     letterSpacing = typographyInputLetterSpacing.sp,
-                    color = if (isDisabled) colorTextMuted else colorTextDefault
+                    color = colorTextDefault
                 ),
                 keyboardOptions = KeyboardOptions(
                     keyboardType = getKeyboardType(type),
@@ -303,7 +297,7 @@ fun InputTextBase(
                 ),
                 keyboardActions = keyboardActions,
                 singleLine = true,
-                readOnly = readOnly || isDisabled,
+                readOnly = readOnly,
                 visualTransformation = if (type == InputType.PASSWORD) {
                     PasswordVisualTransformation()
                 } else {

--- a/src/components/core/Input-Text-Base/platforms/ios/InputTextBase.ios.swift
+++ b/src/components/core/Input-Text-Base/platforms/ios/InputTextBase.ios.swift
@@ -15,15 +15,14 @@
  * - Trailing icon support (error, success, info)
  * - Respects accessibilityReduceMotion
  * - WCAG 2.1 AA compliant
- * - Uses theme-aware blend utilities for state colors (focus, disabled)
- * 
+ * - Uses theme-aware blend utilities for state colors (focus)
+ *
  * Behavioral Contracts:
  * - focusable: Can receive keyboard focus
  * - float_label_animation: Label animates on focus
  * - validates_on_blur: Validation triggers on blur
  * - error_state_display: Shows error message and styling
  * - success_state_display: Shows success styling
- * - disabled_state: Prevents interaction when disabled
  * - trailing_icon_display: Shows contextual trailing icons
  * - focus_ring: WCAG 2.4.7 focus visible indicator
  * - reduced_motion_support: Respects prefers-reduced-motion
@@ -89,10 +88,7 @@ struct InputTextBase: View {
     
     /// Maximum length for input value
     let maxLength: Int?
-    
-    /// Disabled state
-    let isDisabled: Bool
-    
+
     // MARK: - State
     
     /// Whether input currently has focus
@@ -140,8 +136,6 @@ struct InputTextBase: View {
             return theme.colorFeedbackErrorText
         } else if isSuccess {
             return theme.colorFeedbackSuccessText
-        } else if isDisabled {
-            return theme.colorActionPrimary.disabledBlend()
         } else if isFocused {
             return theme.colorActionPrimary.focusBlend()
         } else {
@@ -164,8 +158,6 @@ struct InputTextBase: View {
             return theme.colorFeedbackErrorText
         } else if isSuccess {
             return theme.colorFeedbackSuccessText
-        } else if isDisabled {
-            return theme.colorActionPrimary.disabledBlend()
         } else if isFocused {
             return theme.colorActionPrimary.focusBlend()
         } else {
@@ -220,11 +212,10 @@ struct InputTextBase: View {
                                 isFocused: isFocused,
                                 hasError: hasError,
                                 isSuccess: isSuccess,
-                                isDisabled: isDisabled,
                                 hasTrailingIcon: showErrorIcon || showSuccessIcon || showInfoIconVisible
                             ))
                             .focused($isFocused)
-                            .disabled(readOnly || isDisabled)
+                            .disabled(readOnly)
                             .textContentType(autocomplete)
                             .onChange(of: value) { newValue in
                                 if let maxLength = maxLength, newValue.count > maxLength {
@@ -246,11 +237,10 @@ struct InputTextBase: View {
                                 isFocused: isFocused,
                                 hasError: hasError,
                                 isSuccess: isSuccess,
-                                isDisabled: isDisabled,
                                 hasTrailingIcon: showErrorIcon || showSuccessIcon || showInfoIconVisible
                             ))
                             .focused($isFocused)
-                            .disabled(readOnly || isDisabled)
+                            .disabled(readOnly)
                             .textContentType(autocomplete)
                             .keyboardType(keyboardTypeForInputType(type))
                             .onChange(of: value) { newValue in
@@ -363,7 +353,6 @@ struct InputTextBaseFieldStyle: TextFieldStyle {
     let isFocused: Bool
     let hasError: Bool
     let isSuccess: Bool
-    let isDisabled: Bool
     let hasTrailingIcon: Bool
     
     @Environment(\.accessibilityReduceMotion) var reduceMotion
@@ -373,7 +362,7 @@ struct InputTextBaseFieldStyle: TextFieldStyle {
         configuration
             .font(Font.system(size: DesignTokens.typographyInput.fontSize)
                 .weight(DesignTokens.typographyInput.fontWeight))
-            .foregroundColor(isDisabled ? theme.colorTextMuted : theme.colorTextDefault)
+            .foregroundColor(theme.colorTextDefault)
             .padding(.leading, DesignTokens.spaceInset100)
             .padding(.vertical, DesignTokens.spaceInset100)
             .padding(.trailing, hasTrailingIcon ? 0 : DesignTokens.spaceInset100)
@@ -386,7 +375,7 @@ struct InputTextBaseFieldStyle: TextFieldStyle {
                 RoundedRectangle(cornerRadius: DesignTokens.radius150)
                     .stroke(theme.colorActionPrimary, lineWidth: DesignTokens.accessibilityFocusWidth)
                     .padding(-DesignTokens.accessibilityFocusOffset)
-                    .opacity(isFocused && !isDisabled ? 1 : 0)
+                    .opacity(isFocused ? 1 : 0)
                     .animation(
                         reduceMotion ? .none : Animation.timingCurve(0.4, 0.0, 0.2, 1.0, duration: DesignTokens.MotionFocusTransition.duration),
                         value: isFocused
@@ -417,8 +406,7 @@ struct InputTextBase_Previews: PreviewProvider {
                 placeholder: nil,
                 readOnly: false,
                 required: false,
-                maxLength: nil,
-                isDisabled: false
+                maxLength: nil
             )
             
             InputTextBase(
@@ -437,8 +425,7 @@ struct InputTextBase_Previews: PreviewProvider {
                 placeholder: nil,
                 readOnly: false,
                 required: false,
-                maxLength: nil,
-                isDisabled: false
+                maxLength: nil
             )
             
             InputTextBase(
@@ -457,8 +444,7 @@ struct InputTextBase_Previews: PreviewProvider {
                 placeholder: nil,
                 readOnly: false,
                 required: true,
-                maxLength: nil,
-                isDisabled: false
+                maxLength: nil
             )
             
             InputTextBase(
@@ -477,28 +463,7 @@ struct InputTextBase_Previews: PreviewProvider {
                 placeholder: nil,
                 readOnly: false,
                 required: false,
-                maxLength: nil,
-                isDisabled: false
-            )
-            
-            InputTextBase(
-                id: "preview-disabled",
-                label: "Email",
-                value: .constant("user@example.com"),
-                onChange: nil,
-                onFocus: nil,
-                onBlur: nil,
-                helperText: "This field is disabled",
-                errorMessage: nil,
-                isSuccess: false,
-                showInfoIcon: false,
-                type: .email,
-                autocomplete: .emailAddress,
-                placeholder: nil,
-                readOnly: false,
-                required: false,
-                maxLength: nil,
-                isDisabled: true
+                maxLength: nil
             )
         }
         .padding()

--- a/src/components/core/Input-Text-Email/platforms/android/InputTextEmail.android.kt
+++ b/src/components/core/Input-Text-Email/platforms/android/InputTextEmail.android.kt
@@ -78,7 +78,6 @@ private fun isValidEmail(email: String): Boolean {
  * @param maxLength Maximum length for input value
  * @param imeAction IME action for keyboard
  * @param keyboardActions Keyboard actions
- * @param isDisabled Disabled state
  * @param invalidEmailMessage Custom invalid email message
  * @param customValidator Custom email validator function
  */
@@ -102,7 +101,6 @@ fun InputTextEmail(
     maxLength: Int? = null,
     imeAction: ImeAction = ImeAction.Done,
     keyboardActions: KeyboardActions = KeyboardActions.Default,
-    isDisabled: Boolean = false,
     invalidEmailMessage: String = DEFAULT_INVALID_EMAIL_MESSAGE,
     customValidator: ((String) -> Boolean)? = null
 ) {
@@ -158,8 +156,7 @@ fun InputTextEmail(
         required = required,
         maxLength = maxLength,
         imeAction = imeAction,
-        keyboardActions = keyboardActions,
-        isDisabled = isDisabled
+        keyboardActions = keyboardActions
     )
 }
 

--- a/src/components/core/Input-Text-Email/platforms/ios/InputTextEmail.ios.swift
+++ b/src/components/core/Input-Text-Email/platforms/ios/InputTextEmail.ios.swift
@@ -104,10 +104,7 @@ struct InputTextEmail: View {
     
     /// Maximum length for input value
     let maxLength: Int?
-    
-    /// Disabled state
-    let isDisabled: Bool
-    
+
     /// Custom invalid email message
     let invalidEmailMessage: String
     
@@ -155,7 +152,6 @@ struct InputTextEmail: View {
         readOnly: Bool = false,
         required: Bool = false,
         maxLength: Int? = nil,
-        isDisabled: Bool = false,
         invalidEmailMessage: String = defaultInvalidEmailMessage,
         customValidator: ((String) -> Bool)? = nil
     ) {
@@ -174,7 +170,6 @@ struct InputTextEmail: View {
         self.readOnly = readOnly
         self.required = required
         self.maxLength = maxLength
-        self.isDisabled = isDisabled
         self.invalidEmailMessage = invalidEmailMessage
         self.customValidator = customValidator
     }
@@ -207,8 +202,7 @@ struct InputTextEmail: View {
             placeholder: placeholder,
             readOnly: readOnly,
             required: required,
-            maxLength: maxLength,
-            isDisabled: isDisabled
+            maxLength: maxLength
         )
     }
     
@@ -266,14 +260,6 @@ struct InputTextEmail_Previews: PreviewProvider {
                 value: .constant("user@example.com"),
                 helperText: "Enter your email address",
                 isSuccess: true
-            )
-            
-            InputTextEmail(
-                id: "preview-disabled",
-                label: "Email",
-                value: .constant("user@example.com"),
-                helperText: "This field is disabled",
-                isDisabled: true
             )
             
             InputTextEmail(

--- a/src/components/core/Input-Text-Password/platforms/android/InputTextPassword.android.kt
+++ b/src/components/core/Input-Text-Password/platforms/android/InputTextPassword.android.kt
@@ -122,7 +122,6 @@ private fun validatePasswordRequirements(
  * @param maxLength Maximum length for input value
  * @param imeAction IME action for keyboard
  * @param keyboardActions Keyboard actions
- * @param isDisabled Disabled state
  * @param showToggle Whether to show the toggle button
  * @param isNewPassword Whether this is for a new password
  * @param invalidPasswordMessage Custom invalid password message
@@ -150,7 +149,6 @@ fun InputTextPassword(
     maxLength: Int? = null,
     imeAction: ImeAction = ImeAction.Done,
     keyboardActions: KeyboardActions = KeyboardActions.Default,
-    isDisabled: Boolean = false,
     showToggle: Boolean = true,
     isNewPassword: Boolean = false,
     invalidPasswordMessage: String = DEFAULT_INVALID_PASSWORD_MESSAGE,
@@ -212,8 +210,7 @@ fun InputTextPassword(
                 onClick = {
                     isPasswordVisible = !isPasswordVisible
                     onToggleVisibility?.invoke(isPasswordVisible)
-                },
-                enabled = !isDisabled
+                }
             ) {
                 Icon(
                     imageVector = if (isPasswordVisible) Icons.Filled.VisibilityOff else Icons.Filled.Visibility,
@@ -261,7 +258,6 @@ fun InputTextPassword(
         maxLength = maxLength,
         imeAction = imeAction,
         keyboardActions = keyboardActions,
-        isDisabled = isDisabled,
         trailingContent = toggleButton
     )
 }

--- a/src/components/core/Input-Text-Password/platforms/ios/InputTextPassword.ios.swift
+++ b/src/components/core/Input-Text-Password/platforms/ios/InputTextPassword.ios.swift
@@ -140,10 +140,7 @@ struct InputTextPassword: View {
     
     /// Maximum length for input value
     let maxLength: Int?
-    
-    /// Disabled state
-    let isDisabled: Bool
-    
+
     /// Whether to show the toggle button
     let showToggle: Bool
     
@@ -212,7 +209,6 @@ struct InputTextPassword: View {
         readOnly: Bool = false,
         required: Bool = false,
         maxLength: Int? = nil,
-        isDisabled: Bool = false,
         showToggle: Bool = true,
         isNewPassword: Bool = false,
         invalidPasswordMessage: String = defaultInvalidPasswordMessage,
@@ -235,7 +231,6 @@ struct InputTextPassword: View {
         self.readOnly = readOnly
         self.required = required
         self.maxLength = maxLength
-        self.isDisabled = isDisabled
         self.showToggle = showToggle
         self.isNewPassword = isNewPassword
         self.invalidPasswordMessage = invalidPasswordMessage
@@ -276,7 +271,6 @@ struct InputTextPassword: View {
                     readOnly: readOnly,
                     required: required,
                     maxLength: maxLength,
-                    isDisabled: isDisabled,
                     trailingContent: showToggle ? AnyView(toggleButton) : nil
                 )
             } else {
@@ -307,7 +301,6 @@ struct InputTextPassword: View {
                     readOnly: readOnly,
                     required: required,
                     maxLength: maxLength,
-                    isDisabled: isDisabled,
                     trailingContent: showToggle ? AnyView(toggleButton) : nil
                 )
             }
@@ -327,7 +320,6 @@ struct InputTextPassword: View {
                 .contentShape(Rectangle())
         }
         .buttonStyle(PlainButtonStyle())
-        .disabled(isDisabled)
         .accessibilityLabel(isPasswordVisible ? "Hide password" : "Show password")
         .accessibilityAddTraits(.isButton)
     }
@@ -406,14 +398,6 @@ struct InputTextPassword_Previews: PreviewProvider {
                 value: .constant("StrongP@ss123"),
                 helperText: "Enter your password",
                 isSuccess: true
-            )
-            
-            InputTextPassword(
-                id: "preview-disabled",
-                label: "Password",
-                value: .constant("secretpassword"),
-                helperText: "This field is disabled",
-                isDisabled: true
             )
             
             InputTextPassword(

--- a/src/components/core/Input-Text-PhoneNumber/platforms/android/InputTextPhoneNumber.android.kt
+++ b/src/components/core/Input-Text-PhoneNumber/platforms/android/InputTextPhoneNumber.android.kt
@@ -151,7 +151,6 @@ private fun isValidPhoneNumber(phoneNumber: String, countryCode: String = DEFAUL
  * @param maxLength Maximum length for input value
  * @param imeAction IME action for keyboard
  * @param keyboardActions Keyboard actions
- * @param isDisabled Disabled state
  * @param countryCode Country code for formatting and validation
  * @param autoFormat Whether to auto-format as user types
  * @param invalidPhoneMessage Custom invalid phone message
@@ -177,7 +176,6 @@ fun InputTextPhoneNumber(
     maxLength: Int? = null,
     imeAction: ImeAction = ImeAction.Done,
     keyboardActions: KeyboardActions = KeyboardActions.Default,
-    isDisabled: Boolean = false,
     countryCode: String = DEFAULT_COUNTRY_CODE,
     autoFormat: Boolean = true,
     invalidPhoneMessage: String = DEFAULT_INVALID_PHONE_MESSAGE,
@@ -258,8 +256,7 @@ fun InputTextPhoneNumber(
         required = required,
         maxLength = maxLength,
         imeAction = imeAction,
-        keyboardActions = keyboardActions,
-        isDisabled = isDisabled
+        keyboardActions = keyboardActions
     )
 }
 

--- a/src/components/core/Input-Text-PhoneNumber/platforms/ios/InputTextPhoneNumber.ios.swift
+++ b/src/components/core/Input-Text-PhoneNumber/platforms/ios/InputTextPhoneNumber.ios.swift
@@ -175,10 +175,7 @@ struct InputTextPhoneNumber: View {
     
     /// Maximum length for input value
     let maxLength: Int?
-    
-    /// Disabled state
-    let isDisabled: Bool
-    
+
     /// Country code for formatting and validation
     let countryCode: String
     
@@ -243,7 +240,6 @@ struct InputTextPhoneNumber: View {
         readOnly: Bool = false,
         required: Bool = false,
         maxLength: Int? = nil,
-        isDisabled: Bool = false,
         countryCode: String = defaultCountryCode,
         autoFormat: Bool = true,
         invalidPhoneMessage: String = defaultInvalidPhoneMessage,
@@ -264,7 +260,6 @@ struct InputTextPhoneNumber: View {
         self.readOnly = readOnly
         self.required = required
         self.maxLength = maxLength
-        self.isDisabled = isDisabled
         self.countryCode = countryCode
         self.autoFormat = autoFormat
         self.invalidPhoneMessage = invalidPhoneMessage
@@ -301,8 +296,7 @@ struct InputTextPhoneNumber: View {
             placeholder: placeholder,
             readOnly: readOnly,
             required: required,
-            maxLength: maxLength,
-            isDisabled: isDisabled
+            maxLength: maxLength
         )
         .onAppear {
             // Initialize formatted value from initial value
@@ -394,14 +388,6 @@ struct InputTextPhoneNumber_Previews: PreviewProvider {
                 value: .constant(""),
                 helperText: "Enter your UK phone number",
                 countryCode: "GB"
-            )
-            
-            InputTextPhoneNumber(
-                id: "preview-disabled",
-                label: "Phone Number",
-                value: .constant("5551234567"),
-                helperText: "This field is disabled",
-                isDisabled: true
             )
             
             InputTextPhoneNumber(


### PR DESCRIPTION
**Spec**: n/a — issue cleanup, mirrors the resolved web-side cleanup (Spec 066 Task 3.3)
**Task**: Input-Text-Base native disabled-implementation cleanup
**Unit**: single-unit fix branch
**Agent**: Lina
**Issue record**: `.kiro/issues/input-text-base-disabled-implementation-cleanup.md` (follow-up section, on this branch)
**Validation**: `npx tsc --noEmit` clean; `npm test` 8989/8989 (377/377 suites); performance lanes re-run idle: 44/44 + 32/32

## What

Input-Text-Base's iOS and Android implementations still carried live disabled-state handling — `isDisabled` props, `disabledBlend()` calls, `.disabled(readOnly || isDisabled)`, disabled previews — contradicting the component's own `state_disabled` exclusion (contracts.yaml) and types.ts, which offers `readOnly` as the documented alternative and has never had a `disabled` prop. The 2026-03-01 cleanup removed this from WEB platform files only; all three children (Email, Password, PhoneNumber) inherited the native-side handling via pass-through params.

- **8 platform files** cleaned: Base + Email + Password + PhoneNumber, iOS + Android — props, blend branches, focus-ring gating, pass-throughs, previews, header contract mentions
- **`focusIndicators.test.ts`**: assertions updated from `isFocused && !isDisabled` to `isFocused`
- **`form-inputs-contracts.test.ts`**: dead `disabled_state` CONTRACT_PATTERNS entry replaced with `DISABLED_EXCLUSION_GUARD_PATTERNS`; new exclusion-guard test asserts no Form Inputs platform implementation contains `isDisabled` / `disabledBlend` / `aria-disabled` / `cursor: not-allowed` (Spec 066 / Button-CTA pattern, complements the existing contracts.yaml exclusion checks)
- iOS keeps `.disabled(readOnly)` — SwiftUI's mechanism for the documented `readOnly` prop, not a disabled state (the guard patterns deliberately don't match it)

## Why now

Prerequisite for Ada's staged deprecation of `blend.disabledDesaturate` and the `disabledBlend()` utility extensions (Button-CTA adjudication follow-up #1). These platform-code call sites were invisible to the schema-derived token-consumer index (`consumers: []`); they are now gone on all platforms.

## Notes

- No public API change on web; iOS/Android native params removed were undocumented (absent from types.ts), so no types/schema change needed
- Spotted in passing, not touched: Password's native implementations pass `trailingContent`/`visualTransformation` to `InputTextBase`, which doesn't declare those params (native files aren't compiled in CI) — flagged separately

🤖 Generated with [Claude Code](https://claude.com/claude-code)