### PR TITLE
Remove disabled-state sections from governance docs (no-disabled-states)

### DIFF
--- a/governance/Component-Templates.md
+++ b/governance/Component-Templates.md
@@ -12,7 +12,7 @@ aliases: how do i scaffold a new component, scaffold a new component template, n
 **Scope**: cross-project
 **Layer**: 2
 **Relevant Tasks**: component-development, architecture, spec-planning
-**Last Reviewed**: 2026-07-08
+**Last Reviewed**: 2026-07-15
 
 ---
 
@@ -412,14 +412,6 @@ properties:
       - secondary: [description]
       - tertiary: [description]
   
-  # State properties
-  disabled:
-    type: boolean
-    required: false
-    default: false
-    description: |
-      When true, component is non-interactive with disabled visual styling.
-  
   # Callback properties
   [callbackProp]:
     type: "() => void"
@@ -709,14 +701,12 @@ focusable:
   behavior: |
     Component can receive focus via Tab key navigation.
     Focus state is visually indicated with a focus ring.
-    Focus is managed appropriately when disabled state changes.
   wcag: "2.1.1 Keyboard, 2.4.7 Focus Visible"
   platforms: [web, ios, android]
   validation: |
     - Tab key moves focus to component
     - Focus state is visually distinct with focus ring
     - Focus ring meets 3:1 contrast ratio
-    - Disabled components are not focusable
 ```
 
 #### Pressable Contract
@@ -726,7 +716,7 @@ pressable:
   description: Responds to press/click events
   behavior: |
     Component responds to click, tap, Enter key, and Space key.
-    Press triggers the callback when not disabled.
+    Press triggers the callback.
     Platform-appropriate feedback is provided during press.
   wcag: "2.1.1 Keyboard"
   platforms: [web, ios, android]
@@ -734,7 +724,6 @@ pressable:
     - Click/tap triggers callback
     - Enter key triggers callback
     - Space key triggers callback
-    - Callback not called when disabled
 ```
 
 #### Hoverable Contract
@@ -745,14 +734,12 @@ hoverable:
   behavior: |
     On pointer devices, component shows visual feedback when mouse
     hovers over the component. Uses blend.hoverDarker token.
-    Hover state not shown when disabled.
   wcag: "1.4.13 Content on Hover or Focus"
   platforms: [web, ios, android]
   validation: |
     - Visual feedback shown on mouse enter
     - Visual feedback removed on mouse leave
     - Hover uses blend.hoverDarker token
-    - Hover state not shown when disabled
     - iOS: Only on macOS/iPadOS with pointer
     - Android: Only on desktop/ChromeOS with pointer
 ```
@@ -761,27 +748,37 @@ hoverable:
 
 ### Contract Category 2: State Contracts
 
-#### Disabled State Contract
+#### No Disabled States — Standardized Exclusion
+
+**DesignerPunk components MUST NOT declare a disabled-state contract.** Per the
+2026-07-15 adjudication (`.kiro/issues/button-cta-disabled-state-adjudication.md`),
+the no-disabled-states philosophy now holds corpus-wide with zero exceptions —
+Button-CTA was the last remaining component with a live `disabled_state`
+contract, and it has been removed in favor of the standardized exclusion below.
+
+If an action is temporarily unavailable, use one of these alternatives instead:
+
+- **`state_loading`** — the action is in-flight (async operation running).
+- **Validate-on-press / validate-on-blur** — the action is available but the
+  current input is invalid; surface the error rather than disabling the trigger.
+- **Do not render the component** — if an action is genuinely unavailable
+  (no valid path forward), omit the component entirely rather than rendering
+  it in a disabled state.
+
+Every component's `contracts.yaml` MUST carry the standardized exclusion block
+(mirrored corpus-wide, e.g. `src/components/core/Button-CTA/contracts.yaml`):
 
 ```yaml
-disabled_state:
-  description: Prevents interaction when disabled
-  behavior: |
-    When disabled, component:
-    - Cannot receive focus
-    - Cannot be interacted with
-    - Uses desaturated colors (blend.disabledDesaturate)
-    - Shows cursor: not-allowed (web)
-    - Communicates disabled state to assistive technology
-  wcag: "4.1.2 Name, Role, Value"
-  platforms: [web, ios, android]
-  validation: |
-    - Component cannot receive focus when disabled
-    - Interactions do not trigger callbacks when disabled
-    - Visual styling indicates disabled state
-    - aria-disabled="true" set (web)
-    - Disabled state announced to screen readers
+excludes:
+  state_disabled:
+    reason: "DesignerPunk does not support disabled states for usability and accessibility reasons. If an action is unavailable, the component should not be rendered."
+    category: state
 ```
+
+Do not scaffold a `disabled` prop, a `disabled_state` contract, or any
+disabled-specific validation steps in new components. For the full rationale,
+see the exclusion reason above and the 2026-07-15 adjudication ruling
+(`.kiro/issues/button-cta-disabled-state-adjudication.md`).
 
 #### Error State Contract
 
@@ -830,7 +827,7 @@ loading_state:
   behavior: |
     When in loading state, component:
     - Shows loading spinner or indicator
-    - Prevents interaction (similar to disabled)
+    - Prevents interaction while the async operation is in-flight
     - Maintains dimensions to prevent layout shift
     - Communicates loading state to assistive technology
   wcag: "4.1.3 Status Messages"
@@ -947,7 +944,6 @@ pressed_state:
     - Visual feedback shown during press
     - Feedback uses blend.pressedDarker token
     - Platform-appropriate animation/effect applied
-    - Pressed state not shown when disabled
 ```
 
 #### Gradient Glow Contract
@@ -1084,7 +1080,7 @@ renders_svg:
 | Keyboard navigation | focusable, focus_ring |
 | Click/tap interaction | pressable, pressed_state |
 | Mouse hover feedback | hoverable |
-| Disabled state | disabled_state |
+| Action temporarily unavailable | state_loading (in-flight), validates_on_blur (invalid input), or do not render (no valid path) — never a disabled-state contract; see "No Disabled States — Standardized Exclusion" |
 | Error handling | error_state, validates_on_blur |
 | Success feedback | success_state |
 | Loading indication | loading_state |

--- a/governance/Test-Behavioral-Contract-Validation.md
+++ b/governance/Test-Behavioral-Contract-Validation.md
@@ -14,7 +14,7 @@ description: Framework for validating behavioral contracts across web, iOS, and 
 **Scope**: cross-project
 **Layer**: 2
 **Relevant Tasks**: component-development, cross-platform-validation, testing
-**Last Reviewed**: 2026-07-08
+**Last Reviewed**: 2026-07-15
 
 ---
 
@@ -210,13 +210,11 @@ pressable_validation_checklist:
     - [ ] Click/tap triggers action
     - [ ] Enter key triggers action (web)
     - [ ] Space key triggers action (web)
-    - [ ] Action NOT triggered when disabled
     
   state_validation:
     - [ ] Default state is correct
     - [ ] Hover state appears (desktop only)
     - [ ] Pressed/active state appears
-    - [ ] Disabled state prevents interaction
     
   outcome_validation:
     - [ ] onPress callback is invoked
@@ -226,7 +224,6 @@ pressable_validation_checklist:
     
   accessibility_validation:
     - [ ] role="button" or semantic button (web)
-    - [ ] aria-disabled when disabled (web)
     - [ ] Screen reader announces button
     
   cross_platform_validation:
@@ -305,37 +302,48 @@ error_state_validation_checklist:
     - [ ] Android: TalkBack announces error
 ```
 
-### Disabled State Contract Validation
+### Disabled State Exclusion Guard Validation
 
-**Contract Definition**: Prevents interaction when disabled
+**Provenance**: As of the 2026-07-15 adjudication (`.kiro/issues/button-cta-disabled-state-adjudication.md`), the no-disabled-states philosophy holds corpus-wide with **zero exceptions** — Button-CTA was the last component carrying `state_disabled`, and it has been removed. No component in the corpus may declare a disabled state as a behavioral contract, and `blend.disabledDesaturate` (along with the other disabled-state blend wrappers) is deprecated. Validation for this contract type has inverted: rather than validating that a disabled state behaves correctly, validation now confirms a disabled state does **not exist** and cannot be reintroduced.
+
+**Contract Definition**: Component has no disabled state. Interaction affordances are always active; unavailable actions are handled by not rendering the component (or by another contract — see Philosophy Alternatives below), never by disabling it in place.
+
+**Rationale**: DesignerPunk does not support disabled states for usability and accessibility reasons. If an action is unavailable, the component should not be rendered.
 
 ```yaml
-disabled_state_validation_checklist:
-  trigger_validation:
-    - [ ] Disabled state activates when disabled=true
-    - [ ] Disabled state deactivates when disabled=false
-    
-  state_validation:
-    - [ ] Component cannot receive focus
-    - [ ] Component cannot be clicked/tapped
-    - [ ] Visual styling indicates disabled state
-    - [ ] Cursor shows not-allowed (web)
-    
-  outcome_validation:
-    - [ ] onPress/onChange NOT called when disabled
-    - [ ] Desaturated colors applied (blend.disabledDesaturate)
-    - [ ] Component is visually distinct from enabled
-    
-  accessibility_validation:
-    - [ ] aria-disabled="true" set (web)
-    - [ ] Disabled state communicated to AT
-    - [ ] Component removed from tab order (web)
-    
+disabled_state_exclusion_guard_checklist:
+  schema_validation:
+    - [ ] state_disabled is declared under contracts.yaml `excludes:` (NOT under `contracts:`)
+    - [ ] Excludes entry carries the standardized reason: "DesignerPunk does not support disabled states for usability and accessibility reasons. If an action is unavailable, the component should not be rendered."
+
+  api_surface_validation:
+    - [ ] Component exposes no disabled prop/property
+    - [ ] Component does not list `disabled` in observedAttributes (web) or an equivalent observed-attribute mechanism per platform
+
+  ignored_input_validation:
+    - [ ] A consumer-set disabled attribute is ignored — not forwarded to internal/shadow elements
+    - [ ] No disabled-styling class is applied when a disabled attribute is set
+    - [ ] No aria-disabled (or platform-equivalent) attribute is applied when a disabled attribute is set
+    - [ ] Press/activation still fires normally even when a consumer sets a disabled attribute
+
+  rendered_output_validation:
+    - [ ] No disabled attribute is ever rendered on any platform
+    - [ ] No aria-disabled attribute is ever rendered on any platform
+    - [ ] No platform-equivalent disabled semantic (e.g., Android `enabled = false`, iOS `.disabled()`) is ever applied
+
   cross_platform_validation:
-    - [ ] Web: aria-disabled and tabindex=-1
-    - [ ] iOS: .disabled() modifier applied
-    - [ ] Android: enabled = false in semantics
+    - [ ] Web: no disabled/aria-disabled attribute, no tabindex=-1 for disabled reasons
+    - [ ] iOS: no `.disabled()` modifier applied
+    - [ ] Android: no `enabled = false` in semantics
 ```
+
+**Philosophy Alternatives** — when a spec's design outline reaches for "disabled," redirect to the pattern that actually fits:
+
+- **In-flight async action** → `state_loading` (component shows a loading/busy state; the action remains conceptually available, just pending)
+- **Form input momentarily invalid** → validate-on-press / validate-on-submit (surface the error, do not disable the control)
+- **Action genuinely unavailable** → do not render the component/action at all
+
+**Mirror reference**: `src/components/core/Button-CTA/__tests__/ButtonCTA.test.ts`, `describe('No Disabled State (philosophy exclusion)')` — the canonical exclusion-guard test block this checklist is derived from.
 
 ### Hover State Contract Validation
 
@@ -347,7 +355,6 @@ hover_state_validation_checklist:
     - [ ] Hover state triggers on mouse enter
     - [ ] Hover state clears on mouse leave
     - [ ] Hover state NOT shown on touch devices
-    - [ ] Hover state NOT shown when disabled
     
   state_validation:
     - [ ] Background color changes on hover


### PR DESCRIPTION
**Spec**: none — issue-driven follow-up to `.kiro/issues/button-cta-disabled-state-adjudication.md` (ruled REMOVE, Peter, 2026-07-15)
**Task**: n/a (chore)
**Unit**: single-commit doc alignment
**Agent**: Lina (Component-Templates.md) + Thurgood (Test-Behavioral-Contract-Validation.md), orchestrated by Claude
**Completion doc**: n/a — non-spec chore; the adjudication issue is the record

## What

The last two governance docs teaching disabled states, rewritten by their owners:

- **governance/Component-Templates.md** (Lina): the "Disabled State Contract" template is replaced with **"No Disabled States — Standardized Exclusion"** — teaches the corpus-wide `excludes.state_disabled` block (mirroring `Button-CTA/contracts.yaml`) and the three alternatives (`state_loading`, validate-on-press/blur, don't render). Also removed: the `disabled` prop template, disabled references in the focusable/pressable/hoverable/pressed contract templates, and the quick-reference table row.
- **governance/Test-Behavioral-Contract-Validation.md** (Thurgood): the disabled-state validation checklist is replaced with **exclusion-guard validation** per the Spec 066 / Button-CTA pattern (excludes-block schema check, no disabled prop/observed attribute, consumer-set `disabled` ignored, no disabled/aria-disabled ever rendered), with a mirror reference to `ButtonCTA.test.ts`'s exclusion-guard block. Also removed: disabled items in the pressable and hover checklists.

Reduced-motion "animations disabled" lines left untouched in both docs (different meaning).

## Validation

- Targeted suites referencing these docs pass: `behavioral-contract-validation`, `form-inputs-contracts`, `cross-platform-consistency` — 45/45.
- Full local suite has pre-existing failures in this worktree (module-resolution/partial `dist`), reproduced identically with these changes stashed — not caused by this diff; the PR checks are the clean-checkout gate.

## Follow-up (flagged, not in this PR)

`governance/Component-Development-Guide.md` still carries residual disabled-state mentions despite the adjudication's changes list naming it — flagged for a separate Lina audit.

Touches `governance/**` → Peter-merged per the standing carve-out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
