### PR TITLE
Fix Input-Text native base-call mismatches + add static alignment guard (Input-Text family)

### DIFF
--- a/src/__tests__/stemma-system/input-text-native-base-call-alignment.test.ts
+++ b/src/__tests__/stemma-system/input-text-native-base-call-alignment.test.ts
@@ -1,0 +1,298 @@
+/**
+ * Input-Text Native Base-Call Alignment Validation
+ *
+ * Static analysis tests that validate the native (iOS/Android) Input-Text
+ * semantic variants call InputTextBase with parameters the base actually
+ * declares. The native platform files are NOT compiled in CI — Swift/Kotlin
+ * sources are only validated by static-analysis Jest tests — so a call-site
+ * passing an undeclared parameter (or referencing a nonexistent enum member)
+ * would not compile on a real platform build but previously went undetected.
+ *
+ * Catches:
+ * - Callers passing named arguments the base does not declare
+ *   (e.g., `trailingContent` before the base grew that slot)
+ * - iOS callers passing memberwise-init arguments out of declaration order
+ * - References to InputType enum members that do not exist
+ *   (e.g., `InputType.PHONE` when the enum defines TEL)
+ *
+ * Stemma System: Form Inputs Family
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+const CORE = path.join(__dirname, '../../components/core');
+
+const IOS_BASE = path.join(CORE, 'Input-Text-Base/platforms/ios/InputTextBase.ios.swift');
+const ANDROID_BASE = path.join(CORE, 'Input-Text-Base/platforms/android/InputTextBase.android.kt');
+
+const IOS_CALLERS = [
+  'Input-Text-Password/platforms/ios/InputTextPassword.ios.swift',
+  'Input-Text-Email/platforms/ios/InputTextEmail.ios.swift',
+  'Input-Text-PhoneNumber/platforms/ios/InputTextPhoneNumber.ios.swift',
+].map((p) => path.join(CORE, p));
+
+const ANDROID_CALLERS = [
+  'Input-Text-Password/platforms/android/InputTextPassword.android.kt',
+  'Input-Text-Email/platforms/android/InputTextEmail.android.kt',
+  'Input-Text-PhoneNumber/platforms/android/InputTextPhoneNumber.android.kt',
+].map((p) => path.join(CORE, p));
+
+// ---------------------------------------------------------------------------
+// Source scanning helpers (string- and comment-aware, brace/paren-depth aware)
+// ---------------------------------------------------------------------------
+
+/**
+ * Extract the balanced-parentheses body starting at `openParenIndex`
+ * (which must point at a '('). Skips string literals and line comments.
+ */
+function extractParenBody(source: string, openParenIndex: number): string {
+  let depth = 0;
+  for (let i = openParenIndex; i < source.length; i++) {
+    const ch = source[i];
+    if (ch === '"') {
+      // Skip string literal (handles escapes)
+      i++;
+      while (i < source.length && source[i] !== '"') {
+        if (source[i] === '\\') i++;
+        i++;
+      }
+    } else if (ch === '/' && source[i + 1] === '/') {
+      while (i < source.length && source[i] !== '\n') i++;
+    } else if (ch === '(') {
+      depth++;
+    } else if (ch === ')') {
+      depth--;
+      if (depth === 0) {
+        return source.slice(openParenIndex + 1, i);
+      }
+    }
+  }
+  throw new Error('Unbalanced parentheses in source');
+}
+
+/**
+ * Split an argument/parameter list into top-level entries — commas nested
+ * inside (), {}, [], strings, or line comments do not split.
+ */
+function splitTopLevel(body: string): string[] {
+  const parts: string[] = [];
+  let depth = 0;
+  let current = '';
+  for (let i = 0; i < body.length; i++) {
+    const ch = body[i];
+    if (ch === '"') {
+      current += ch;
+      i++;
+      while (i < body.length && body[i] !== '"') {
+        if (body[i] === '\\') {
+          current += body[i];
+          i++;
+        }
+        current += body[i];
+        i++;
+      }
+      current += body[i] ?? '';
+    } else if (ch === '/' && body[i + 1] === '/') {
+      while (i < body.length && body[i] !== '\n') i++;
+      current += '\n';
+    } else if ('({['.includes(ch)) {
+      depth++;
+      current += ch;
+    } else if (')}]'.includes(ch)) {
+      depth--;
+      current += ch;
+    } else if (ch === ',' && depth === 0) {
+      parts.push(current);
+      current = '';
+    } else {
+      current += ch;
+    }
+  }
+  if (current.trim()) parts.push(current);
+  return parts;
+}
+
+/** Find every `InputTextBase(...)` call in a source file and return its args. */
+function extractBaseCalls(source: string): string[][] {
+  const calls: string[][] = [];
+  const re = /\bInputTextBase\(/g;
+  let match: RegExpExecArray | null;
+  while ((match = re.exec(source)) !== null) {
+    const body = extractParenBody(source, match.index + match[0].length - 1);
+    calls.push(splitTopLevel(body));
+    re.lastIndex = match.index + match[0].length;
+  }
+  return calls;
+}
+
+/** Labels of named arguments: Swift `label: value` / Kotlin `name = value`. */
+function argLabel(arg: string, platform: 'ios' | 'android'): string | null {
+  const m =
+    platform === 'ios'
+      ? arg.match(/^\s*(\w+)\s*:/)
+      : arg.match(/^\s*(\w+)\s*=(?!=)/);
+  return m ? m[1] : null;
+}
+
+// ---------------------------------------------------------------------------
+// Base declaration parsers
+// ---------------------------------------------------------------------------
+
+/**
+ * iOS base: settable stored properties of the InputTextBase struct, in
+ * declaration order. These define the memberwise initializer, so caller
+ * argument labels must be an in-order subsequence of this list.
+ * Excludes private state (@State/@FocusState/@Environment are all private)
+ * and the `body` computed property.
+ */
+function parseIOSBaseProperties(source: string): string[] {
+  const structStart = source.indexOf('struct InputTextBase: View {');
+  const bodyStart = source.indexOf('var body: some View', structStart);
+  const section = source.slice(structStart, bodyStart);
+  const props: string[] = [];
+  for (const line of section.split('\n')) {
+    if (line.includes('private')) continue;
+    const m = line.match(/^\s*(?:@Binding\s+)?(?:let|var)\s+(\w+)\s*[:=]/);
+    if (m) props.push(m[1]);
+  }
+  return props;
+}
+
+/** Android base: parameter names of the InputTextBase composable function. */
+function parseAndroidBaseParams(source: string): string[] {
+  const funIndex = source.indexOf('fun InputTextBase(');
+  const body = extractParenBody(source, funIndex + 'fun InputTextBase'.length);
+  return splitTopLevel(body)
+    .map((p) => p.match(/^\s*(\w+)\s*:/)?.[1])
+    .filter((name): name is string => Boolean(name));
+}
+
+/** Enum members: Swift `case xyz` / Kotlin `enum class InputType { A, B }`. */
+function parseInputTypeMembers(source: string, platform: 'ios' | 'android'): string[] {
+  if (platform === 'ios') {
+    const enumStart = source.indexOf('enum InputType {');
+    const enumBody = source.slice(enumStart, source.indexOf('}', enumStart));
+    return [...enumBody.matchAll(/case\s+(\w+)/g)].map((m) => m[1]);
+  }
+  const enumMatch = source.match(/enum class InputType \{([^}]*)\}/);
+  if (!enumMatch) return [];
+  return enumMatch[1]
+    .split(',')
+    .map((m) => m.trim())
+    .filter(Boolean);
+}
+
+/** Assert `subset` appears within `sequence` in order (subsequence check). */
+function isInOrderSubsequence(subset: string[], sequence: string[]): boolean {
+  let cursor = 0;
+  for (const item of subset) {
+    const found = sequence.indexOf(item, cursor);
+    if (found === -1) return false;
+    cursor = found + 1;
+  }
+  return true;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('Input-Text native base-call alignment', () => {
+  const iosBaseSource = fs.readFileSync(IOS_BASE, 'utf-8');
+  const androidBaseSource = fs.readFileSync(ANDROID_BASE, 'utf-8');
+
+  const iosBaseProps = parseIOSBaseProperties(iosBaseSource);
+  const androidBaseParams = parseAndroidBaseParams(androidBaseSource);
+  const iosEnumMembers = parseInputTypeMembers(iosBaseSource, 'ios');
+  const androidEnumMembers = parseInputTypeMembers(androidBaseSource, 'android');
+
+  describe('base declaration parsing (sanity)', () => {
+    it('parses the iOS base memberwise properties', () => {
+      expect(iosBaseProps).toEqual(
+        expect.arrayContaining(['id', 'label', 'value', 'type', 'isDisabled', 'trailingContent'])
+      );
+      expect(iosBaseProps.length).toBeGreaterThanOrEqual(15);
+    });
+
+    it('parses the Android base composable parameters', () => {
+      expect(androidBaseParams).toEqual(
+        expect.arrayContaining(['id', 'label', 'value', 'type', 'visualTransformation', 'trailingContent'])
+      );
+      expect(androidBaseParams.length).toBeGreaterThanOrEqual(15);
+    });
+
+    it('parses the InputType enums on both platforms', () => {
+      expect(iosEnumMembers).toEqual(['text', 'email', 'password', 'tel', 'url']);
+      expect(androidEnumMembers).toEqual(['TEXT', 'EMAIL', 'PASSWORD', 'TEL', 'URL']);
+    });
+  });
+
+  describe('iOS callers', () => {
+    // The iOS base preview also exercises the memberwise initializer
+    const files = [...IOS_CALLERS, IOS_BASE];
+
+    files.forEach((file) => {
+      const name = path.basename(file);
+
+      it(`${name}: every InputTextBase argument is a declared property, in declaration order`, () => {
+        const source = fs.readFileSync(file, 'utf-8');
+        const calls = extractBaseCalls(source);
+        expect(calls.length).toBeGreaterThan(0);
+
+        calls.forEach((args) => {
+          const labels = args
+            .map((a) => argLabel(a, 'ios'))
+            .filter((l): l is string => Boolean(l));
+
+          const undeclared = labels.filter((l) => !iosBaseProps.includes(l));
+          expect(undeclared).toEqual([]);
+
+          // Memberwise init requires arguments in property declaration order
+          expect(isInOrderSubsequence(labels, iosBaseProps)).toBe(true);
+        });
+      });
+
+      it(`${name}: type argument references a declared InputType case`, () => {
+        const source = fs.readFileSync(file, 'utf-8');
+        extractBaseCalls(source).forEach((args) => {
+          const typeArg = args.find((a) => argLabel(a, 'ios') === 'type');
+          if (!typeArg) return;
+          const caseMatch = typeArg.match(/:\s*\.(\w+)/);
+          if (caseMatch) {
+            expect(iosEnumMembers).toContain(caseMatch[1]);
+          }
+        });
+      });
+    });
+  });
+
+  describe('Android callers', () => {
+    ANDROID_CALLERS.forEach((file) => {
+      const name = path.basename(file);
+
+      it(`${name}: every InputTextBase named argument is a declared parameter`, () => {
+        const source = fs.readFileSync(file, 'utf-8');
+        const calls = extractBaseCalls(source);
+        expect(calls.length).toBeGreaterThan(0);
+
+        calls.forEach((args) => {
+          const labels = args
+            .map((a) => argLabel(a, 'android'))
+            .filter((l): l is string => Boolean(l));
+          expect(labels.length).toBeGreaterThan(0);
+
+          const undeclared = labels.filter((l) => !androidBaseParams.includes(l));
+          expect(undeclared).toEqual([]);
+        });
+      });
+
+      it(`${name}: every InputType reference is a declared enum member`, () => {
+        const source = fs.readFileSync(file, 'utf-8');
+        const refs = [...source.matchAll(/\bInputType\.(\w+)/g)].map((m) => m[1]);
+        const unknown = refs.filter((r) => !androidEnumMembers.includes(r));
+        expect(unknown).toEqual([]);
+      });
+    });
+  });
+});

--- a/src/components/core/Input-Text-Base/Input-Text-Base.schema.yaml
+++ b/src/components/core/Input-Text-Base/Input-Text-Base.schema.yaml
@@ -11,7 +11,7 @@
 name: Input-Text-Base
 type: primitive
 family: FormInput
-version: "1.0.0"
+version: "1.1.0"
 readiness:
   web:
     reviewed: true
@@ -24,6 +24,16 @@ composition:
   internal:
     - component: Icon-Base
       role: Trailing contextual icon (error, success, info)
+      required: false
+  slots:
+    - name: trailingContent
+      description: >-
+        Trailing content slot rendered after the status icons. Semantic
+        variants use it to inject interactive trailing controls (e.g.,
+        Input-Text-Password's visibility toggle). Native platforms only
+        (iOS: AnyView?, Android: @Composable lambda) — the web base has no
+        equivalent slot; web variants render trailing controls in their
+        own Shadow DOM.
       required: false
 
 # Component description
@@ -188,9 +198,23 @@ platform_notes:
   ios:
     implementation: SwiftUI View
     file: platforms/ios/InputTextBase.ios.swift
+    notes: |
+      Platform composition parameters (not part of the cross-platform props):
+      - trailingContent: AnyView? = nil — trailing content slot (see composition.slots)
+      Masking: type .password renders SecureField; other types render TextField.
+      Variants toggle visibility by switching type between .password and .text.
   android:
     implementation: Jetpack Compose Composable
     file: platforms/android/InputTextBase.android.kt
+    notes: |
+      Platform composition parameters (not part of the cross-platform props):
+      - modifier, imeAction, keyboardActions — standard Compose passthroughs
+      - visualTransformation: VisualTransformation? = null — masking override;
+        null derives from type (PasswordVisualTransformation for PASSWORD)
+      - trailingContent: (@Composable () -> Unit)? = null — trailing content
+        slot (see composition.slots)
+      Variants toggle password visibility via visualTransformation while
+      keeping type = PASSWORD (preserves the password keyboard type).
 
 # Semantic components that inherit from this primitive
 semantic_variants:

--- a/src/components/core/Input-Text-Base/README.md
+++ b/src/components/core/Input-Text-Base/README.md
@@ -151,6 +151,21 @@ InputTextBase(
 | `testID` | `string` | No | - | Test ID for automated testing |
 | `className` | `string` | No | - | Additional CSS class names (web only) |
 
+### Platform Composition Parameters (native only)
+
+These parameters exist on the native implementations for platform composition —
+they are not part of the cross-platform props contract above:
+
+| Parameter | Platform | Type | Default | Description |
+|-----------|----------|------|---------|-------------|
+| `trailingContent` | iOS | `AnyView?` | `nil` | Trailing content slot rendered after the status icons (e.g., Input-Text-Password's visibility toggle) |
+| `trailingContent` | Android | `(@Composable () -> Unit)?` | `null` | Same slot, Compose form |
+| `visualTransformation` | Android | `VisualTransformation?` | `null` | Masking override; `null` derives from `type` (`PasswordVisualTransformation` for `PASSWORD`). Lets variants toggle password visibility while keeping the password keyboard type |
+| `modifier`, `imeAction`, `keyboardActions` | Android | — | — | Standard Compose passthroughs |
+
+The web base has no trailing slot equivalent — web semantic variants render
+trailing controls inside their own Shadow DOM.
+
 ---
 
 ## Token Consumption
@@ -220,6 +235,13 @@ Legacy type aliases are provided for backward compatibility during migration.
 ---
 
 ## Changelog
+
+### v1.1.0 (July 2026)
+
+- Native bases gain a `trailingContent` composition slot (iOS `AnyView?`, Android `@Composable` lambda) so semantic variants can inject trailing controls — required by Input-Text-Password's visibility toggle
+- Android base gains a `visualTransformation` override (null = derived from `type`) so variants can toggle masking without changing the input type
+- Fixed Input-Text-PhoneNumber native callers referencing nonexistent enum members (`.phone`/`PHONE` → `.tel`/`TEL`)
+- Added static base-call alignment test (`src/__tests__/stemma-system/input-text-native-base-call-alignment.test.ts`) guarding native call sites against parameter/enum drift
 
 ### v1.0.0 (January 2026)
 

--- a/src/components/core/Input-Text-Base/platforms/android/InputTextBase.android.kt
+++ b/src/components/core/Input-Text-Base/platforms/android/InputTextBase.android.kt
@@ -13,6 +13,7 @@
  * - Color animation (text.subtle → primary with blend.focusSaturate)
  * - Offset animation (translateY)
  * - Trailing icon support (error, success, info)
+ * - Trailing content slot for semantic variants (e.g., password toggle)
  * - Respects reduce motion settings
  * - WCAG 2.1 AA compliant
  * - Uses theme-aware blend utilities for state colors (focus, disabled)
@@ -99,6 +100,9 @@ enum class InputType {
  * @param isSuccess Success state indicator
  * @param showInfoIcon Info icon support
  * @param type Input type
+ * @param visualTransformation Override for the input's visual transformation.
+ *        When null, derived from type (PasswordVisualTransformation for PASSWORD).
+ *        Semantic variants use this to control masking (e.g., password visibility toggle).
  * @param placeholder Placeholder text (only shown when label is floated and input is empty)
  * @param readOnly Read-only state
  * @param required Required field indicator
@@ -106,6 +110,8 @@ enum class InputType {
  * @param imeAction IME action for keyboard
  * @param keyboardActions Keyboard actions
  * @param isDisabled Disabled state
+ * @param trailingContent Trailing content slot rendered after the status icons
+ *        (e.g., password visibility toggle)
  */
 @Composable
 fun InputTextBase(
@@ -121,13 +127,15 @@ fun InputTextBase(
     isSuccess: Boolean = false,
     showInfoIcon: Boolean = false,
     type: InputType = InputType.TEXT,
+    visualTransformation: VisualTransformation? = null,
     placeholder: String? = null,
     readOnly: Boolean = false,
     required: Boolean = false,
     maxLength: Int? = null,
     imeAction: ImeAction = ImeAction.Done,
     keyboardActions: KeyboardActions = KeyboardActions.Default,
-    isDisabled: Boolean = false
+    isDisabled: Boolean = false,
+    trailingContent: (@Composable () -> Unit)? = null
 ) {
     // State
     var isFocused by remember { mutableStateOf(false) }
@@ -304,7 +312,7 @@ fun InputTextBase(
                 keyboardActions = keyboardActions,
                 singleLine = true,
                 readOnly = readOnly || isDisabled,
-                visualTransformation = if (type == InputType.PASSWORD) {
+                visualTransformation = visualTransformation ?: if (type == InputType.PASSWORD) {
                     PasswordVisualTransformation()
                 } else {
                     VisualTransformation.None
@@ -373,6 +381,9 @@ fun InputTextBase(
                     )
                 }
             }
+
+            // Trailing content slot (e.g., password visibility toggle)
+            trailingContent?.invoke()
         }
         
         // Helper text (persistent)

--- a/src/components/core/Input-Text-Base/platforms/ios/InputTextBase.ios.swift
+++ b/src/components/core/Input-Text-Base/platforms/ios/InputTextBase.ios.swift
@@ -13,6 +13,7 @@
  * - Color animation (text.subtle → primary with blend.focusSaturate)
  * - Offset animation (translateY)
  * - Trailing icon support (error, success, info)
+ * - Trailing content slot for semantic variants (e.g., password toggle)
  * - Respects accessibilityReduceMotion
  * - WCAG 2.1 AA compliant
  * - Uses theme-aware blend utilities for state colors (focus, disabled)
@@ -92,7 +93,12 @@ struct InputTextBase: View {
     
     /// Disabled state
     let isDisabled: Bool
-    
+
+    /// Trailing content slot rendered after the status icons
+    /// (e.g., password visibility toggle). Declared as `var` with a
+    /// default so the memberwise initializer keeps it optional and last.
+    var trailingContent: AnyView? = nil
+
     // MARK: - State
     
     /// Whether input currently has focus
@@ -221,7 +227,7 @@ struct InputTextBase: View {
                                 hasError: hasError,
                                 isSuccess: isSuccess,
                                 isDisabled: isDisabled,
-                                hasTrailingIcon: showErrorIcon || showSuccessIcon || showInfoIconVisible
+                                hasTrailingIcon: showErrorIcon || showSuccessIcon || showInfoIconVisible || trailingContent != nil
                             ))
                             .focused($isFocused)
                             .disabled(readOnly || isDisabled)
@@ -247,7 +253,7 @@ struct InputTextBase: View {
                                 hasError: hasError,
                                 isSuccess: isSuccess,
                                 isDisabled: isDisabled,
-                                hasTrailingIcon: showErrorIcon || showSuccessIcon || showInfoIconVisible
+                                hasTrailingIcon: showErrorIcon || showSuccessIcon || showInfoIconVisible || trailingContent != nil
                             ))
                             .focused($isFocused)
                             .disabled(readOnly || isDisabled)
@@ -294,6 +300,12 @@ struct InputTextBase: View {
                             reduceMotion ? .none : Animation.timingCurve(0.4, 0.0, 0.2, 1.0, duration: DesignTokens.MotionFloatLabel.duration),
                             value: showInfoIconVisible
                         )
+                }
+
+                // Trailing content slot (e.g., password visibility toggle)
+                if let trailingContent = trailingContent {
+                    trailingContent
+                        .padding(.trailing, DesignTokens.spaceInset100)
                 }
             }
             .frame(minHeight: DesignTokens.tapAreaRecommended)

--- a/src/components/core/Input-Text-Password/Input-Text-Password.schema.yaml
+++ b/src/components/core/Input-Text-Password/Input-Text-Password.schema.yaml
@@ -262,13 +262,15 @@ platform_notes:
   ios:
     implementation: SwiftUI View wrapping InputTextBase
     file: platforms/ios/InputTextPassword.ios.swift
-    toggle: Button with SF Symbol eye/eye.slash
+    toggle: Button with SF Symbol eye/eye.slash, injected via the base's trailingContent slot
     autocomplete: UITextContentType.password or .newPassword
+    visibility: Toggles by switching base type between .password and .text
   android:
     implementation: Jetpack Compose Composable wrapping InputTextBase
     file: platforms/android/InputTextPassword.android.kt
-    toggle: IconButton with visibility icons
+    toggle: IconButton with visibility icons, injected via the base's trailingContent slot
     autocomplete: Autofill framework password type
+    visibility: Toggles via the base's visualTransformation override (type stays PASSWORD)
 
 # Inheritance relationship
 inheritance:

--- a/src/components/core/Input-Text-PhoneNumber/platforms/android/InputTextPhoneNumber.android.kt
+++ b/src/components/core/Input-Text-PhoneNumber/platforms/android/InputTextPhoneNumber.android.kt
@@ -252,7 +252,7 @@ fun InputTextPhoneNumber(
         errorMessage = effectiveErrorMessage,
         isSuccess = isSuccess,
         showInfoIcon = showInfoIcon,
-        type = InputType.PHONE,
+        type = InputType.TEL,
         placeholder = placeholder,
         readOnly = readOnly,
         required = required,

--- a/src/components/core/Input-Text-PhoneNumber/platforms/ios/InputTextPhoneNumber.ios.swift
+++ b/src/components/core/Input-Text-PhoneNumber/platforms/ios/InputTextPhoneNumber.ios.swift
@@ -296,7 +296,7 @@ struct InputTextPhoneNumber: View {
             errorMessage: effectiveErrorMessage,
             isSuccess: isSuccess,
             showInfoIcon: showInfoIcon,
-            type: .phone,
+            type: .tel,
             autocomplete: .telephoneNumber,
             placeholder: placeholder,
             readOnly: readOnly,


### PR DESCRIPTION
**Spec**: n/a — ad-hoc component fix (non-spec work, `fix/` branch per conventions)
**Task**: Input-Text native base-call alignment
**Agent**: Lina
**Unit**: this PR (single-unit fix)

## Problem

The native Input-Text sources are not compiled in CI (static-analysis Jest only), which let four would-not-compile defects sit undetected:

1. iOS Password passed `trailingContent:` to `InputTextBase` — base declared no such property
2. Android Password passed `visualTransformation =` and `trailingContent =` — base declared neither
3. Android PhoneNumber passed `InputType.PHONE` — enum defines `TEL`
4. iOS PhoneNumber passed `type: .phone` — enum defines `.tel` (found during investigation; not in the original report)

## Fix (decision: extend the base, not restructure Password)

`contracts.yaml` requires the password toggle on all three platforms and the native Passwords use composition, so the bases grew the missing capability:

- **iOS base**: `trailingContent: AnyView?` slot (defaulted `var` — memberwise init stays compatible with Email/PhoneNumber call sites); renders after status icons, feeds `hasTrailingIcon` padding
- **Android base**: `trailingContent: (@Composable () -> Unit)?` slot + `visualTransformation: VisualTransformation?` override (null = derived from `type`, so existing callers are behavior-identical). Android needs the override because visibility toggling must unmask while keeping `type = PASSWORD` (preserves password keyboard); iOS instead switches `type` between `.password`/`.text`
- **PhoneNumber callers**: aligned to `TEL`/`.tel`
- **Docs**: `composition.slots` entry + platform notes in the Base schema (v1.1.0), README platform-composition table + changelog, Password schema platform notes now name the slot dependency

## Guard

New `src/__tests__/stemma-system/input-text-native-base-call-alignment.test.ts` (17 tests): every named argument in a native `InputTextBase(...)` call must be a declared base parameter; iOS arguments must follow memberwise declaration order; every `InputType` reference must be a declared enum member. **Mutation-checked**: against the pre-fix sources it fails 6 tests, catching all four defects.

## Validation

- New suite: 17/17 pass
- stemma-system + Input-Text family suites: 666/667 (single failure = known fresh-worktree missing `dist/` artifact, unrelated)
- Full `npm test`: only the known 33-suite fresh-worktree baseline (missing generated artifacts), none related
- Edited YAML parses cleanly (js-yaml)

🤖 Generated with [Claude Code](https://claude.com/claude-code)