### PR TITLE
Fix disabled-state residue and verified drift in token docs (no-disabled-states)

### DIFF
--- a/docs/token-system-overview.md
+++ b/docs/token-system-overview.md
@@ -40,7 +40,7 @@ This document is organized for efficient MCP section queries. Use `get_section` 
 | Shadow | 23 | 8 | ✅ Complete |
 | Glow | 9 | 3 | ✅ Complete |
 | Blend | 5 | 7 | ✅ Complete |
-| Opacity | 14 | 8 | ✅ Complete |
+| Opacity | 14 | 4 | ✅ Complete |
 | Border Width | 3 | 5 | ✅ Complete |
 | Layering | - | 12 | ✅ Complete |
 | Motion | 12 | 1+ | ✅ Complete |
@@ -381,12 +381,12 @@ if (validationResult.valid) {
 #### Semantic Opacity Tokens
 - **File**: `src/tokens/semantic/OpacityTokens.ts`
 - **Description**: Purpose-driven opacity values
-- **Tokens**: opacity.disabled, opacity.overlay, opacity.hover, opacity.pressed, opacity.ghost
+- **Tokens**: opacity.subtle, opacity.medium, opacity.heavy, opacity.ghost
 
 #### Semantic Blend Tokens
 - **File**: `src/tokens/semantic/BlendTokens.ts`
 - **Description**: Contextual blend amounts for interaction states
-- **Tokens**: blend.hoverDarker, blend.hoverLighter, blend.pressedDarker, blend.focusSaturate, blend.disabledDesaturate (DEPRECATED 2026-07-15 — no disabled states; removal at next major), blend.containerHoverDarker, color.icon.opticalBalance
+- **Tokens**: blend.hoverDarker, blend.hoverLighter, blend.pressedDarker, blend.pressedLighter, blend.focusSaturate, blend.disabledDesaturate (DEPRECATED 2026-07-15 — no disabled states; removal at next major), blend.containerHoverDarker, color.icon.opticalBalance
 - **Related Guides**:
   - [Blend Tokens Guide](./tokens/blend-tokens.md)
   - [Blend Infrastructure Design](../.kiro/specs/031-blend-infrastructure-implementation/design.md)
@@ -598,7 +598,7 @@ Four blend operations are available on all platforms:
 | `darkerBlend(color, amount)` | Darken a color | Hover states, pressed states |
 | `lighterBlend(color, amount)` | Lighten a color | Icon optical balance |
 | `saturate(color, amount)` | Increase saturation | Focus states |
-| `desaturate(color, amount)` | Decrease saturation | Disabled states |
+| `desaturate(color, amount)` | Decrease saturation | Deprecated disabled-state usage (blend.disabledDesaturate, 2026-07-15) — no current consumer; calculator retained for backward compatibility |
 
 ### Generated Files
 
@@ -633,14 +633,14 @@ val hoverColor = MaterialTheme.colorScheme.primary.darkerBlend(BlendTokens.hover
 
 ### Component Integration
 
-All four core components use blend utilities:
+Blend utilities are used across the component library. Representative examples:
 
 | Component | Blend Usage |
 |-----------|-------------|
-| ButtonCTA | hover (darkerBlend), pressed (darkerBlend), icon (lighterBlend) |
-| TextInputField | focus (saturate), disabled (desaturate) |
-| Container | hover (darkerBlend) |
-| Icon | optical balance (lighterBlend) |
+| Button-CTA | hover (darkerBlend), pressed (darkerBlend), icon (lighterBlend) |
+| Input-Text-Base | focus (saturate) |
+| Container-Base | hover (darkerBlend) |
+| Icon-Base | optical balance (lighterBlend) |
 
 ### Validation
 

--- a/governance/rosetta-system-principles.md
+++ b/governance/rosetta-system-principles.md
@@ -138,7 +138,7 @@ Mathematical foundation allows documented exceptions for design requirements:
 | **Radius** | Shape definition | radius100, radius200 | radius.button, radius.card |
 | **Shadow** | Depth and elevation | shadowBlur200, shadowOpacity300 | shadow.container, shadow.modal |
 | **Glow** | Emphasis effects | glowBlur200, glowOpacity100 | glow.focus, glow.highlight |
-| **Opacity** | Transparency | opacity048, opacity080 | opacity.disabled, opacity.hover |
+| **Opacity** | Transparency | opacity048, opacity080 | opacity.ghost, opacity.heavy |
 | **Blend** | Color modification | blend100, blend200 | blend.hoverDarker, blend.focusSaturate |
 | **Border** | Edge definition | borderWidth100, borderWidth200 | border.input, border.focus |
 | **Motion** | Animation timing | duration250, easingStandard | motion.floatLabel |

--- a/src/blend/__tests__/InteractionStateAudit.test.ts
+++ b/src/blend/__tests__/InteractionStateAudit.test.ts
@@ -129,8 +129,10 @@ describe('Spec 112 Task 5.1: Interaction State Visual Audit', () => {
 
   describe('Disabled state (ΔC ≥ 0.03 reduction)', () => {
     // No component declares a disabled state (no-disabled-states philosophy).
-    // This validates the calculator capability only, kept until the
-    // blend.disabledDesaturate token's deprecation is adjudicated (Ada).
+    // blend.disabledDesaturate was deprecated 2026-07-15 (PR #83, Button-CTA
+    // disabled-state adjudication). This test validates the calculator
+    // capability only, retained for backward compatibility; remove at the
+    // next major version alongside the token itself.
     it('calculator disabled blend — ΔC reduction meets minimum', () => {
       const result = calc.interactionBlend(primaryButton, 'disabled', lightSurface);
       const dc = deltaC(primaryButton, result);

--- a/src/tokens/OpacityTokens.ts
+++ b/src/tokens/OpacityTokens.ts
@@ -113,7 +113,7 @@ export const opacityTokens: Record<string, PrimitiveToken> = {
     category: TokenCategory.OPACITY,
     baseValue: OPACITY_BASE_VALUE * 6,
     familyBaseValue: OPACITY_BASE_VALUE,
-    description: 'Disabled state - faded, very strong overlay',
+    description: 'Very strong transparency - background scrims and modal overlays (referenced by opacity.heavy)',
     mathematicalRelationship: 'base × 6 = 0.08 × 6 = 0.48',
     baselineGridAlignment: false,
     isStrategicFlexibility: false,

--- a/src/tokens/__tests__/OpacityTokens.test.ts
+++ b/src/tokens/__tests__/OpacityTokens.test.ts
@@ -280,7 +280,9 @@ describe('Opacity Tokens', () => {
       
       expect(opacity000?.description).toContain('Fully transparent');
       expect(opacity008?.description).toContain('Subtle transparency');
-      expect(opacity048?.description).toContain('Disabled state');
+      // opacity048 description corrected 2026-07-15: disabled-state phrasing removed
+      // (no-disabled-states philosophy, Button-CTA adjudication)
+      expect(opacity048?.description).toContain('Very strong transparency');
       expect(opacity100?.description).toContain('Fully opaque');
     });
 

--- a/src/tokens/semantic/OpacityTokens.ts
+++ b/src/tokens/semantic/OpacityTokens.ts
@@ -6,10 +6,10 @@
  * the design system while maintaining semantic meaning.
  * 
  * Opacity values:
- * - subtle: 0.9 (90%) - Minimal transparency for subtle effects
- * - medium: 0.7 (70%) - Moderate transparency for overlays
- * - heavy: 0.5 (50%) - Strong transparency for backgrounds
- * - ghost: 0.3 (30%) - Maximum transparency for ghost effects
+ * - subtle: opacity088 (88%) - Minimal transparency for subtle effects
+ * - medium: opacity072 (72%) - Moderate transparency for overlays
+ * - heavy: opacity048 (48%) - Strong transparency for backgrounds
+ * - ghost: opacity032 (32%) - Maximum transparency for ghost effects
  * 
  * All opacity tokens reference primitive opacity values that can be applied
  * to any color or surface for consistent transparency effects.


### PR DESCRIPTION
**Spec**: n/a — issue-driven cleanup, follow-through on `.kiro/issues/button-cta-disabled-state-adjudication.md` + the blend.disabledDesaturate deprecation (PR #83)
**Unit**: token-doc residue, narrow stage (Ada's owned surfaces)
**Agent**: Ada (Sonnet, delegated; findings pre-verified by a second Ada review)

Post-merge verification found `docs/token-system-overview.md` was only partially treated by the adjudication cleanup, and the stale lines revealed doc-vs-source drift. This PR is the **narrow stage** Ada recommended: disabled contradictions + already-verified one-line corrections. The fuller source-vs-doc audit is a separate follow-up unit.

## Changes
- **`docs/token-system-overview.md`** — semantic opacity token list corrected (`opacity.disabled/overlay/hover/pressed` were fabricated; real set is `subtle/medium/heavy/ghost`), inventory count 8→4, missing `blend.pressedLighter` added, `desaturate()` use case reworded from "Disabled states" to the deprecation note, Component Integration table fixed (real component names — `TextInputField` doesn't exist — removed disabled usage dropped, each remaining blend claim verified against component source).
- **`governance/rosetta-system-principles.md`** — nonexistent `opacity.disabled`/`opacity.hover` examples replaced with real tokens (`opacity.ghost`, `opacity.heavy`).
- **`src/tokens/OpacityTokens.ts`** — `opacity048` description no longer teaches a disabled-state use case (now grounded in its real consumer, `opacity.heavy`); the test assertion pinning the old string synced with a comment citing the adjudication.
- **`src/tokens/semantic/OpacityTokens.ts`** — header comment listed 0.9/0.7/0.5/0.3; actual primitives are opacity088/072/048/032. Comment-only.
- **`src/blend/__tests__/InteractionStateAudit.test.ts`** — stale comment ("kept until the deprecation is adjudicated") updated: deprecation happened 2026-07-15; calculator retained until next major. Comment-only.

## Deferred to the follow-up audit unit (known, on record)
Broken `./tokens/blend-tokens.md`/`shadow-tokens.md` links; Last-Reviewed refresh; the line-383 composition-table row (`color.primary + opacity.hover` — both halves drifted, needs a unit fix); `blend.iconLighter` vs `color.icon.opticalBalance` naming drift in component comments; `BlendTokens.ts` header says "7 tokens" but defines 8; full 34-component blend-usage audit.

## Validation
Targeted suites: `InteractionStateAudit.test.ts` 63/63, opacity suites (primitive + semantic) 53/53. Docs + comment-only source changes otherwise; no token values or test logic altered. Post-edit greps: remaining `disabled` hits are the DEPRECATED annotation and philosophy references only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)