### PR TITLE
Remove disabled-state examples from Process-Spec-Planning (no-disabled-states)

### DIFF
--- a/governance/Process-Spec-Planning.md
+++ b/governance/Process-Spec-Planning.md
@@ -35,7 +35,7 @@ description: Standards for creating spec documents — requirements format (EARS
 
 1. ✅ **Component-Templates** - Query "Behavioral Contract Templates" section for:
    - Interaction contracts (Focusable, Pressable, Hoverable)
-   - State contracts (Disabled, Error, Success, Loading)
+   - State contracts (Error, Success, Loading)
    - Accessibility contracts (Focus Ring, Reduced Motion, Screen Reader Hidden)
    - Visual contracts (Pressed State, Float Label Animation)
 
@@ -439,7 +439,7 @@ During spec formalization (design-outline → requirements.md), Thurgood will id
 
 **Contract Traceability:**
 - Every platform implementation subtask in a component spec must include `_Contracts:` lines listing the contracts that subtask satisfies
-- Format: `_Contracts: interaction_focusable, interaction_pressable, state_disabled_`
+- Format: `_Contracts: interaction_focusable, interaction_pressable, state_loading_`
 - This maps implementation work to behavioral guarantees, enabling review and audit
 
 ### Task Format Examples


### PR DESCRIPTION
**Spec**: n/a — issue-driven cleanup, follow-through on `.kiro/issues/button-cta-disabled-state-adjudication.md`
**Unit**: single-doc governance cleanup (Thurgood's owned surface)
**Agent**: Thurgood (Sonnet, delegated)

Two examples in `governance/Process-Spec-Planning.md` taught spec authors to reference the banned `state_disabled` contract:
- Line 442 — the `_Contracts:` annotation format example. Now uses `state_loading`, a real contract declared in Button-CTA's own `contracts.yaml` alongside the two interaction contracts in the example.
- Line 38 — the Component-Templates query guidance listed "Disabled" among state contracts to look up (caught by Thurgood's case-insensitive scan; earlier sweeps grepped lowercase only).

Deliberately NOT changed: `governance/Contract-System-Reference.md`'s `state_disabled` catalog entry and naming example — Lina (domain owner) ruled these correct to keep, since every component's `excludes.state_disabled` block requires the concept and canonical name to exist; the yaml example at line 162 is itself the excludes-block illustration.

## Validation
Docs-only, two-line change. Post-edit `grep -in disabled` on the file returns zero hits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)