### PR TITLE
Record deferral of iOS readOnly .focusable prototype (readonly adjudication)

### DIFF
--- a/.kiro/issues/ios-readonly-focusable-prototype.md
+++ b/.kiro/issues/ios-readonly-focusable-prototype.md
@@ -2,7 +2,11 @@
 
 **Date**: 2026-07-15
 **Owner**: Kenya (assigned in the iOS readOnly adjudication, condition 2 — accepted in [KENYA R2])
-**Status**: OPEN — requires real hardware; cannot run from this repo
+**Status**: OPEN — DEFERRED (Peter, 2026-07-15: no hardware access currently;
+revisit in a later roadmap phase). Until then the `interaction_focusable`
+iOS readOnly carve-out stands as the declared, mitigable exception the
+contract words it as — nothing degrades by waiting, and the auto-tighten
+clause fires whenever this runs.
 **Source**: `.kiro/issues/input-text-base-ios-readonly-adjudication.md`, RULED B-prime (Peter, 2026-07-15)
 
 ---


### PR DESCRIPTION
**Spec**: n/a — record-keeping on `.kiro/issues/ios-readonly-focusable-prototype.md`
**Unit**: single-file status note
**Agent**: coordinator (recording Peter's decision)

Peter cannot run the on-device Full Keyboard Access prototype currently; deferred to a later roadmap phase. This records the deferral so the tracker reflects reality: the `interaction_focusable` iOS readOnly carve-out stands as the declared, mitigable exception the contract already words it as — the auto-tighten clause fires whenever the prototype eventually runs. Per Data's recorded dissent, the ledger entry (iOS keyboard users served worse than Android's for read-only content until then) remains on the record.

## Validation
Docs-only, one status field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)