### PR TITLE
Delete unused test:quick script (single-file-selection footgun) (chore)

### DIFF
--- a/.kiro/specs/release-analysis-system/performance-test-analysis.md
+++ b/.kiro/specs/release-analysis-system/performance-test-analysis.md
@@ -4,6 +4,8 @@
 **Purpose**: Analyze slow performance/stress tests and provide recommendations
 **Context**: Test suite taking 1683 seconds (~28 minutes) with performance tests timing out
 
+> **Historical record.** The package.json snippets below reflect November 2025. The lane semantics were reworked 2026-07-03 (commit `29bba7de`), and `test:quick` was **removed 2026-08-02** (unused; single-file-selection footgun in its trailing array-typed `--testPathIgnorePatterns`). See Start Up Tasks for current commands.
+
 ---
 
 ## Current State

--- a/.kiro/specs/release-analysis-system/test-command-implementation.md
+++ b/.kiro/specs/release-analysis-system/test-command-implementation.md
@@ -4,6 +4,8 @@
 **Purpose**: Document implementation of separated test commands for improved developer experience
 **Context**: Implemented hybrid approach to separate performance tests from regular test runs
 
+> **Historical record — command set and durations superseded.** The 2026-07-03 lane rework (commit `29bba7de`) made the default lanes timing-assertion-free and fast (~1 min warm), voiding the durations below. `npm run test:quick` was **removed 2026-08-02**: unused by CI/hooks/steering, its "ultra-fast" rationale no longer held, and its trailing `--testPathIgnorePatterns` (an array-typed jest option) made `npm run test:quick -- <file>` ADD the file as an ignore pattern instead of selecting it. Current command guidance lives in Start Up Tasks.
+
 ---
 
 ## Implementation Summary

--- a/package.json
+++ b/package.json
@@ -113,7 +113,6 @@
     "test:resolution-matrix": "node src/config/__resolution-matrix__/run-matrix.js",
     "test:performance": "jest --testPathPatterns='performance/__tests__|__tests__/performance'",
     "test:performance:isolated": "jest --config jest.performance.config.js --runInBand",
-    "test:quick": "jest --testPathIgnorePatterns='(performance|integration)'",
     "test:watch": "jest --watch --testPathIgnorePatterns='performance/__tests__|__tests__/performance'",
     "test:coverage": "jest --coverage --testPathIgnorePatterns='performance/__tests__|__tests__/performance'",
     "release:analyze": "npx tsx src/tools/release/cli/release-tool.ts analyze",


### PR DESCRIPTION
Spec: n/a (chore — spawned follow-up from the npm test single-file-selection fix)
Task: Delete test:quick per Peter's decision 2026-08-02
Agent: Claude (main session)
Unit: this chore (single commit)

## What

- Removes the root `test:quick` script from package.json.
- Adds dated removal notes to the two historical docs that documented it (`.kiro/specs/release-analysis-system/test-command-implementation.md`, `performance-test-analysis.md`) — records preserved, not rewritten.

## Why deletion (Peter's call, offered delete vs. lane-config fix)

- Same footgun as the `npm test` one fixed on `fix/npm-test-single-file-selection`: trailing array-typed `--testPathIgnorePatterns` means `npm run test:quick -- <file>` ADDS the file as an ignore pattern instead of selecting it.
- Unused: no CI workflow, hook, or steering doc references it — only the two historical spec docs.
- Rationale void: since the 2026-07-03 lane rework (`29bba7de`), `test:quick` was just `npm test` minus 22 integration suites (~6%) on a ~1-minute lane; skipping integration coverage invites false-green validation.

## Validation

- `npx jest --listTests` diff: `npm test` selection unchanged (378 suites); `test:quick` was a strict subset (356), so nothing else shifts.
- package.json parses; repo-wide grep shows no remaining operational `test:quick` references.

Note: touches package.json scripts near lines also edited by the open `fix/npm-test-single-file-selection` branch — trivial to resolve in whichever merges second.

🤖 Generated with [Claude Code](https://claude.com/claude-code)