### PR TITLE
Replace RTL aliases with form-inputs vocabulary on Component-Family-Form-Inputs (chore)

### DIFF
--- a/governance/Component-Family-Form-Inputs.md
+++ b/governance/Component-Family-Form-Inputs.md
@@ -3,7 +3,7 @@ id: component-family-form-inputs
 inclusion: manual
 name: Component-Family-Form-Inputs
 description: Form Inputs component family — text input (float label pattern), checkbox, and radio components with built-in validation, accessibility, and cross-platform consistency. Load when working with form components, input validation, or selection controls.
-aliases: RTL, internationalization, i18n, bidi, right-to-left, text direction
+aliases: textfield, text field, textbox, form field, input field, form controls
 ---
 
 # Form Inputs Components
@@ -14,7 +14,7 @@ aliases: RTL, internationalization, i18n, bidi, right-to-left, text direction
 **Scope**: cross-project
 **Layer**: 3
 **Relevant Tasks**: component-development, ui-composition, component-implementation
-**Last Reviewed**: 2026-02-07
+**Last Reviewed**: 2026-08-02
 
 ---
 

--- a/mcp-server/src/query/__tests__/find-docs-calibration.test.ts
+++ b/mcp-server/src/query/__tests__/find-docs-calibration.test.ts
@@ -28,9 +28,7 @@
  * | concept query          | must include                           | expected tier |
  * |------------------------|----------------------------------------|---------------|
  * | "RTL"                  | Web-Authoring-Standards.md             | strong        |
- * |                        | Component-Family-Form-Inputs.md        | strong        |
  * | "internationalization" | Web-Authoring-Standards.md             | strong        |
- * |                        | Component-Family-Form-Inputs.md        | strong        |
  * | "spec planning"        | Process-Spec-Planning.md               | strong        |
  * | "EARS"                 | Process-Spec-Planning.md               | strong        |
  * | incidental-token case  | only incidental match                  | partial       |
@@ -60,7 +58,6 @@ const STEERING_DIR = path.resolve(__dirname, '../../../../governance');
  * absolute-path prefixes do not make the fixture brittle to CWD differences).
  */
 const RTL_DOC_A = 'Web-Authoring-Standards.md';
-const RTL_DOC_B = 'Component-Family-Form-Inputs.md';
 const SPEC_PLANNING_DOC = 'Process-Spec-Planning.md';
 
 // ---------------------------------------------------------------------------
@@ -132,7 +129,16 @@ describe('find_docs calibration fixtures — real corpus, tool boundary (Task 4.
   // Fixture 1 — RTL / right-to-left
   // -------------------------------------------------------------------------
 
-  describe('fixture: "RTL" → Web-Authoring-Standards.md + Component-Family-Form-Inputs.md (strong via aliases)', () => {
+  describe('fixture: "RTL" → Web-Authoring-Standards.md (strong via aliases)', () => {
+    /**
+     * NOTE (119-B Task 4 alias prune, 2026-08-02): Component-Family-Form-Inputs.md
+     * previously carried the same RTL alias set as a second calibration fixture
+     * (Spec 121 Task 5). Its only RTL content was two passing bullets, so the
+     * aliases were replaced with form-inputs-scoped vocabulary (Lina's domain
+     * ruling). The RTL/internationalization recall floor is satisfied by
+     * Web-Authoring-Standards.md alone, which has real RTL/logical-properties
+     * content and keeps its aliases.
+     */
     let result: FindDocsHandlerResult;
 
     beforeAll(() => {
@@ -155,23 +161,8 @@ describe('find_docs calibration fixtures — real corpus, tool boundary (Task 4.
       expect(entry!.matchConfidence).toBe('strong');
     });
 
-    it('includes Component-Family-Form-Inputs.md', () => {
-      const entry = findEntry(result, RTL_DOC_B);
-      expect(entry).toBeDefined();
-    });
-
-    it('classifies Component-Family-Form-Inputs.md as strong (aliases high-signal hit)', () => {
-      const entry = findEntry(result, RTL_DOC_B);
-      expect(entry!.matchConfidence).toBe('strong');
-    });
-
     it('emits three distinct Layer fields on Web-Authoring-Standards.md (criterion b)', () => {
       const entry = findEntry(result, RTL_DOC_A);
-      assertThreeDistinctLayers(entry!);
-    });
-
-    it('emits three distinct Layer fields on Component-Family-Form-Inputs.md (criterion b)', () => {
-      const entry = findEntry(result, RTL_DOC_B);
       assertThreeDistinctLayers(entry!);
     });
 
@@ -186,7 +177,7 @@ describe('find_docs calibration fixtures — real corpus, tool boundary (Task 4.
   // Fixture 2 — internationalization
   // -------------------------------------------------------------------------
 
-  describe('fixture: "internationalization" → same two docs (strong)', () => {
+  describe('fixture: "internationalization" → Web-Authoring-Standards.md (strong)', () => {
     let result: FindDocsHandlerResult;
 
     beforeAll(() => {
@@ -195,12 +186,6 @@ describe('find_docs calibration fixtures — real corpus, tool boundary (Task 4.
 
     it('includes Web-Authoring-Standards.md at strong', () => {
       const entry = findEntry(result, RTL_DOC_A);
-      expect(entry).toBeDefined();
-      expect(entry!.matchConfidence).toBe('strong');
-    });
-
-    it('includes Component-Family-Form-Inputs.md at strong', () => {
-      const entry = findEntry(result, RTL_DOC_B);
       expect(entry).toBeDefined();
       expect(entry!.matchConfidence).toBe('strong');
     });


### PR DESCRIPTION
**Spec**: n/a — issue-driven chore, routed from 119-B Task 4 alias-prune consult
**Task**: Form-inputs aliases drift fix (Lina's drift-flag-for-fix ruling, recorded in `.kiro/specs/119-B-capability-routing-measurement/findings/alias-prune.md` § Flags, 2026-08-02)
**Agent**: Lina (doc ruling + edits), orchestrated by Claude Fable 5
**Unit**: this PR (single chore unit)

## What & why

`governance/Component-Family-Form-Inputs.md` carried `aliases: RTL, internationalization, i18n, bidi, right-to-left, text direction` — strong-tier RTL routing backed by only two passing RTL bullets in the doc body.

Git history check (read-history-before-recommending): the aliases were added **deliberately** in `0414863c` (Spec 121 Task 5, 2026-06-23) — Form-Inputs was tagged as a *second calibration fixture* to close the RTL recall floor, not as considered i18n routing for the family. Lina's ruling as domain owner: replace with form-inputs-scoped vocabulary. Web-Authoring-Standards.md (real logical-properties/RTL content) keeps its RTL aliases and satisfies the recall floor alone.

## Changes

- **Component-Family-Form-Inputs.md**: aliases → `textfield, text field, textbox, form field, input field, form controls` (vocabulary gaps not covered by the indexed title/description); `Last Reviewed` → 2026-08-02.
- **find-docs-calibration.test.ts**: RTL/internationalization fixtures now assert Web-Authoring-Standards.md only (structural three-layer + `matchedOn` assertions intact); dated note records the ruling; spec-planning/EARS/partial/none fixtures untouched.

## Validation

- mcp-server suite: **36/36 suites, 598/598 tests pass** (includes the updated calibration fixtures against the real edited corpus).
- Spot-verified via the tool-boundary handler (`handleFindDocs`) on the edited corpus: `textfield` and `form field` → Form-Inputs rank-1 **strong** (aliases hit); `RTL` / `internationalization` → Web-Authoring-Standards only; `form input family work` → Form-Inputs rank-1 strong (title tie-breaker preserved).
- Root suite not run locally (worktree lacks generated artifacts; change touches only a governance doc + one mcp-server test) — the PR gate's required checks are the authoritative full-suite run.

## Post-merge note

The live docs MCP index should be rebuilt (`rebuild_index`) after merge so the alias change takes effect in served `find_docs` results.

🤖 Generated with [Claude Code](https://claude.com/claude-code)