### PR TITLE
Task 10 Complete: Closeout verification and record (119-B)

### DIFF
--- a/.kiro/specs/119-B-capability-routing-measurement/completion/task-10-completion.md
+++ b/.kiro/specs/119-B-capability-routing-measurement/completion/task-10-completion.md
@@ -1,0 +1,52 @@
+# Task 10 Completion: Closeout Verification and Record
+
+**Date**: 2026-08-02
+**Task**: 10 — Closeout verification and record
+**Type**: Documentation · **Validation**: Tier 1
+**Unit**: U-close (`task/119-B-uclose`) — spec complete at this PR's merge
+**Status**: Complete on branch
+
+---
+
+## THE R9 AC5 GATE (checkable, not aspirational): PASSES
+
+**OB-1 is MERGED** — PR #103, merged 2026-08-02T16:26:26Z (squash `938ddddd`). Not descoped; no descope record needed. The gate that would have BLOCKED closeout does not fire.
+
+## Regen-log audit against K=3 + R10 sunset state
+
+- **`regen-log.md` does not exist — lawfully.** The 125-B pilot window CLOSED at N=20 (pass-2 PR #104, 2026-08-02T16:36Z; U1-c closeout #105 RATIFIED) **before any qualifying regen occurred**: 119-B's only two generator runs were (i) OB-1's provably-null registry sync (zero output delta — not a qualifying regen; auditable record in task-7-4-completion.md) and (ii) U-final's ONE batched regen (post-close; post-sunset regens don't log, R10 AC6 — record in task-9-3-completion.md). The log expires with the window; there are no `segment occurred?` cells to fill because no line ever qualified.
+- **K=3 audit result**: 119-B consumed ZERO window segments (the window's own dataset confirms segments=2 final, boundary events 1 of K=3, none attributable to 119-B). Regen count vs the ≤2 target: 1 qualifying-regen-shaped event total (U-final's), post-sunset. Window discipline auditable end-to-end from the window dataset + completion docs (success criterion 3, met without a regen log by construction).
+- **R10 sunset VERIFIED and recorded**: window closed → R10 AC1–5 vacuously satisfied for all 119-B work from Task 8 onward; the AC2-style window-state records were kept anyway (task-7-4, task-9-3, findings verification record) — over-documentation in the safe direction.
+
+## Findings artifacts: complete + cited (verified)
+
+| Artifact | Complete per schema | Cited by |
+|---|---|---|
+| `findings/measurement-case-study.md` | Component 5 (5 sections incl. coverage boundary, ladder, shadowing check, OB-4 input) | task-3-completion.md ✓ |
+| `findings/alias-prune.md` | Data Models per-alias schema (27 rows, tallies, flags) | task-4-completion.md (explicit R4 AC5 acceptance line) ✓ |
+| `findings/catalog-routing-audit.md` | Component 1 (per-agent sections, promotion tables, 8.3 confirmation record, Task 9 verification record) | task-8-completion.md + task-9-completion.md + PR #106 body (declared content-review basis) ✓ |
+
+**Civitas health-check attribution note VERIFIED in OB-1's completion doc**: task-7-completion.md § "Before/after evidence" carries the flagged attribution table (crossReferences 116 → 327 attributed to OB-1, cite-this-doc instruction for the monthly check). ✓
+
+## Folder-rename issue trigger status (recorded, NOT silently absorbed)
+
+`.kiro/issues/2026-07-19-spec-119-folder-rename.md` — **TRIGGER FIRED at this closeout** (its own terms: "execute at 119-B closeout, before Spec 123 opens"). Disposition: **EXECUTE, spun off as its OWN issue-driven action** per the issue's owner/routing — a dedicated session was dispatched 2026-08-02 (background-task chip, atomic `git mv` + cross-ref sweep + single PR per the issue's execution notes). This record satisfies the execute-or-record clause: the trigger did NOT pass unexecuted and was NOT absorbed into this task. (If that session's PR is not merged before Spec 123 opens, the issue's keep-or-execute decision point re-arms — the issue file remains the tracker.)
+
+## Spec-level success criteria (final audit)
+
+1. **Four pillar deliverables landed** ✓ — catalog audited/refined + routing gap-filled/precision-audited (U-final, #106: 97 promotions, 8 additions incl. both 118 rows); calibration formalized (register row #96 ratified + AICP refinement #102 + generated 4c cue #106); measurement case study recorded with honest attribution (#99).
+2. **OB-1–4 discharged** ✓ — OB-1 merged (#103, parser enumerates bare-id refs); OB-2 sweep done (#101 + PDW fold in #106, 0 residual); OB-3 prune measured (#101, 27 aliases, gate clear); OB-4 decision recorded (#96, keep rank ≤ 2 — U2's distribution agreed, no amendment).
+3. **Window discipline auditable, ≤ K=3** ✓ — zero segments consumed by 119-B; trail above.
+4. **Every SHALL traceable** ✓ — R1–R2 (task-1/2 docs + register row), R3 (findings + task-3), R4–R5 (findings/completion docs per Decision 6 homes), R6–R8 (findings + task-8/9 docs; R6 AC3 as amended by Peter 2026-08-02, ratified at #106's merge), R9 (task-7 docs), R10 (sunset records), R11 (D1/re-probe/index-rebuild evidence throughout).
+
+## Deviations register (closeout-grade honesty, consolidated)
+
+- R6 AC3 amended mid-execution (Peter, recorded, ratified at #106) — premise gap, escalated not improvised.
+- Task 1's ratification interpreted as merge-time presentation (Peter re-affirmed post-hoc during the 125-B/119-B reading mixup review).
+- Register row carries four beyond-schema YAML keys (design § 4a fields; flagged to Peter, accepted).
+- Thurgood's 118 heading landed at the verbatim spec-stamped form, not the design's paraphrase (emission-gate correction).
+- All delegated-tier deltas captured per-task (main-loop Fable 5 throughout; consults Sonnet).
+
+## Delegated-tier note
+
+Planned: Thurgood (Sonnet). Actual: main-loop session (Fable 5), consistent with the full spec run. Agent-evolution: none. Model-evolution: none.

--- a/.kiro/specs/119-B-capability-routing-measurement/tasks.md
+++ b/.kiro/specs/119-B-capability-routing-measurement/tasks.md
@@ -128,7 +128,7 @@ Window law (R10), binding WHILE the 125-B window is open: regens batch (target �
 
 ### Unit U-close — Closeout
 
-- [ ] 10. Closeout verification and record
+- [x] 10. Closeout verification and record
   - **Type**: Documentation · **Agent**: Thurgood (Sonnet) · **Validation**: Tier 1
   - **THE R9 AC5 GATE (checkable, not aspirational): verify the OB-1 unit is MERGED or DESCOPED-BY-RECORD (ballot/committed record). Anything else BLOCKS closeout.**
   - Audit the regen log against K=3 (occurred column); fill any pending `segment occurred?` cells; verify the R10 sunset state (window closed → ACs vacuously satisfied, recorded)


### PR DESCRIPTION
**Spec**: 119-B-capability-routing-measurement
**Unit**: U-close — closeout (single-parent unit, Task 10). **Merging this PR completes Spec 119-B.**
**Task**: 10 — Closeout verification and record
**Agent**: Thurgood
**Completion docs**:
- .kiro/specs/119-B-capability-routing-measurement/completion/task-10-completion.md
**Validation**: Tier 1 documentation closeout; npm test 378/9020 green locally; all gates verified

---

## The gates, verified

- **R9 AC5 (the checkable gate): PASSES** — OB-1 MERGED (#103). Nothing blocks closeout.
- **Regen-log / K=3 audit**: `regen-log.md` lawfully never existed — the window closed at N=20 before any qualifying regen; 119-B consumed ZERO segments; the U-final regen ran post-sunset. Full trail in the completion doc.
- **Three findings artifacts complete + cited** by their completion docs; the crossReferences 116→327 health-check attribution note verified in OB-1's completion doc.
- **Folder-rename issue: trigger FIRED and honored** — executed as its own issue-driven action (dedicated session dispatched per the issue's routing), recorded, not silently absorbed and not silently slid.

## Spec-level outcome (the four pillars + OB-1–4, all landed)

Catalog audited + refined and routing gap-filled (#106: 97 promotions, 8 additions, both 118 rows) · calibration formalized end-to-end (register row ratified #96 → AICP refined #102 → generated cue #106) · measurement case study with honest attribution (#99: 83/83, baseline preserved) · OB-1 parser unit (#103: crossRefs 116→327) · OB-2 sweep (#101 + PDW fold #106, 0 residual) · OB-3 prune (#101: 27 aliases, gate clear) · OB-4 decision (#96, measurement-confirmed at #99). One requirements amendment (R6 AC3, Peter 2026-08-02) recorded and ratified at #106. Deviations register consolidated in the completion doc.

---
Squash-merge only — the PR title becomes the `main` commit subject. **The spec is complete at MERGE** (ballot 125-A, Item 1d).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
