### PR TITLE
Q6 resolved: release-manager retirement ballot + execution issue (chore)

### DIFF
--- a/.kiro/docs/ballots/2026-08-12-q6-release-manager-retirement.md
+++ b/.kiro/docs/ballots/2026-08-12-q6-release-manager-retirement.md
@@ -1,0 +1,38 @@
+# Ballot Measure: Q6 Resolution — Retire the Release Manager (kill-and-rewrite)
+
+**Date**: 2026-08-12
+**Author**: Thurgood (Civitas steward), from the Q6 discussion session (2026-08-11 evening → 2026-08-12 morning)
+**Status**: **RATIFIED (Peter, 2026-08-12)** — ratified in-session after the chartered audit pre-work was presented (inventory + consumption trace + the v14.0.0 live-trial evidence), Peter's two concerns addressed and folded into scope, recorded record-first before the execution PR.
+**Purpose**: Resolve parked question Q6 (chartered by Peter 2026-07-12, Spec 125 design-outline §10: *"How does the release manager evolve with the new infrastructure — what do we keep, kill, or evolve?"* with audit pre-work owed). **Verdict: KILL the tool; capture its surviving value as documentation.**
+
+---
+
+## The evidence (audit pre-work, discharged)
+
+1. **Live trial (v14.0.0, 2026-08-12)**: of the tool's five functions, the release used ZERO. `release:analyze` recommended 13.0.1-patch and classified all 34 changes "Other"; `release:notes` generated "No consumer-facing changes" against a breaking component wave; `release:run` was skipped so it would not overwrite the correct hand-authored notes; tag + GitHub release took two ordinary commands; `NpmPublisher.ts` was never wired. Record: `docs/releases/release-14.0.0.md` (authorship note), PR #114.
+2. **Structural blindness, permanent and growing**: the tool reads spec task-summary docs; issue-driven work (a recorded standing practice) is invisible to it. Its fix would be a rewrite of its input layer onto squash-PR titles — data the PR gate already makes answerable with one `git log`.
+3. **Consumption trace**: the structured `.json`/`.internal` artifacts have ZERO consumers (code, agents, knowledge bases, docs — swept). The post-merge `release-analysis` workflow prints (wrong) analysis to run summaries nobody reads.
+4. **What actually protected the release** — the publish guard scripts (`check:drift`, `verify:token-index-clean`, the `prepublishOnly` chain) — is NOT part of the release manager and is untouched by this ballot.
+5. **Trajectory**: the tool itself replaced a 203-file predecessor (Spec 065). This verdict continues that simplification one step further, now that the gate provides what the tool compensated for.
+
+## Peter's two concerns, addressed in scope (2026-08-12)
+
+- **C1 — agents' "what changed and why" discovery**: lives in the record chain (squash titles → release notes → task summaries → ballots/register), NOT in the tool. The rewritten mental-model doc SHALL carry a "discovering what changed and why" section teaching that chain (MCP-served + consumer-shipped). The release-notes documents practice CONTINUES (proven consumer: 123's `inbound-from-13.0.0-release.md`). **Recorded deferral**: whether release notes should ship/serve to consumers is a Spec 123 consideration (upgrade/sync story), not decided here.
+- **C2 — dependency sweep before deletion**: swept 2026-08-12 — **36 referencing files**, including 2 always-loaded steering docs (Task-Completion-Protocol "the release tool scans" clause; start-up-tasks' test-command decision tree keying on "modifies release tool" ×3), 7 governance docs, 12 `docs/examples/` tutorials + CI-integration examples, 3 hook surfaces + `complete-task.sh`'s banner, 2 diagnostic scripts, the CI workflow, and the tool + 11 test files. Full inventory + per-file adjudication: the execution issue (below).
+
+## The ratified verdict
+
+1. **KILL**: `src/tools/release/` (24 files) + its 11 test files; `.github/workflows/release-analysis.yml`; `scripts/validate-release-setup.js` + `scripts/diagnose-release-issues.js` (+ fixture); `release-manager.sh`, the release-detection hook, `analyze-after-commit` hook surfaces; the `release:*`, `validate:release-setup`, `diagnose:release-issues` package scripts. `NpmPublisher.ts` dies with the tool.
+2. **REWRITE**: `governance/release-management-system.md` becomes the mental model of the RECIPE (derive delta from squash titles → classify consumer-facing impact → Peter ratifies the bump → hand-authored notes → guard scripts protect publish → manual tag + `gh release create`), including the C1 discovery-chain section. `RELEASE-FLOW.md` gains the derive-classify-ratify section. Steering-law amendments (TCP clause; start-up-tasks decision-tree branch) ride a Peter-merged governance PR.
+3. **ARCHIVE / keep-as-history**: `docs/release-management/` guides and `docs/examples/` release tutorials + CI templates (adjudicated per-file at execution — archive location or deletion with the history in git); Spec 065/101 records untouched (history).
+4. **KEEP untouched**: publish guard scripts; the notes-documents practice; `docs/releases/` records; squash-title discipline (its value is now the changelog spine itself, independent of any tool).
+
+## Execution
+
+Issue-driven per the recorded pattern (this ballot is the design): `.kiro/issues/2026-08-12-release-manager-retirement-execution.md` carries the inventory checklist. Execution runs as its own focused session; the sweep re-runs at execution start (point-in-time counts are never load-bearing). Steering/governance edits are governance-law: Peter-merged. Removing `release-analysis.yml` is NOT a required-check-set change (it was never a required context) — no measurement-window consequence.
+
+## Counter-arguments on the record (AICP)
+
+- Killing loses structured release metadata → it has zero consumers; if 123's install-doc/upgrade story needs structured release data, build against that real requirement then.
+- Evolve-instead (input-layer rewrite onto PR titles) → maintains a standing tool for a quarterly task a session performs in minutes; rejected as machinery without a bite.
+- The tool represents past investment (065's rebuild) → the investment's surviving value IS the simplification trajectory this ballot continues.

--- a/.kiro/issues/2026-08-12-release-manager-retirement-execution.md
+++ b/.kiro/issues/2026-08-12-release-manager-retirement-execution.md
@@ -1,0 +1,41 @@
+# Issue: Release-Manager Retirement — Execution (Q6 ballot application)
+
+**Date**: 2026-08-12
+**Authority**: ballot `.kiro/docs/ballots/2026-08-12-q6-release-manager-retirement.md` (RATIFIED — Peter, 2026-08-12; the ballot is the design, this issue is the checklist)
+**Owner**: Thurgood coordinates; steering/governance edits Peter-merged
+**Status**: OPEN — execute in a dedicated session. **Re-run the reference sweep at execution start** (`grep -rln "release:analyze\|release:notes\|release:run\|release-tool\|release manager\|release-analysis\|NpmPublisher\|release-management"`) — the inventory below is point-in-time (2026-08-12), never load-bearing.
+
+---
+
+## Checklist (per-file adjudication classes from the ballot)
+
+### DELETE (tool + machinery)
+- [ ] `src/tools/release/` (24 TS files incl. `NpmPublisher.ts`) + its 11 `*.test.ts`
+- [ ] `.github/workflows/release-analysis.yml` (never a required context — no gate/window consequence)
+- [ ] `scripts/validate-release-setup.js`, `scripts/diagnose-release-issues.js`, `scripts/__fixtures__/discovery-oracle.ts` (verify this fixture is release-only before deleting — it matched the sweep; if shared, retarget instead)
+- [ ] `.kiro/hooks/release-manager.sh`, `.kiro/hooks/release-detection-manual.kiro.hook`, `.kiro/hooks/analyze-after-commit-README.md` (verify no live hook registration references them)
+- [ ] `package.json` scripts: `release:analyze`, `release:notes`, `release:run`, `validate:release-setup`, `diagnose:release-issues`
+- [ ] Full `npm test` + `tsc` after deletions (11 test files leave the suite; count change is expected — record before/after)
+
+### UPDATE (law + live teaching surfaces — governance PR, Peter-merged)
+- [ ] `.kiro/steering/Task-Completion-Protocol.md` :80 — "preserving the atomic-commit-per-task history the release tool scans" → title-discipline rationale stands on its own (the changelog spine)
+- [ ] `.kiro/steering/start-up-tasks.md` — test-command decision tree ×3: "modifies release tool" branch → re-anchor (e.g., "performance-critical systems" alone)
+- [ ] `governance/release-management-system.md` — REWRITE to the recipe mental-model + the C1 "discovering what changed and why" chain (squash titles → `docs/releases/` notes → task summaries → ballots/register)
+- [ ] `.kiro/hooks/RELEASE-FLOW.md` — add the derive-classify-ratify section (v14's proven sequence incl. dual-registry playbook pointer + guard scripts)
+- [ ] `.kiro/hooks/complete-task.sh` — remove the "Release analysis runs post-merge" banner line
+- [ ] Remaining governance references, adjudicate each: `Process-Development-Workflow.md`, `Process-Hook-Operations.md`, `Process-Spec-Planning.md`, `completion-documentation-guide.md`, `Test-Failure-Audit-Methodology.md`, `BUILD-SYSTEM-SETUP.md`, `.kiro/hooks/README.md`, `docs/testing/test-infrastructure-guide.md`
+- [ ] Docs-MCP `rebuild_index` after governance edits; steering-metadata validation on touched docs
+
+### ARCHIVE or DELETE (per-file call at execution; git history preserves regardless)
+- [ ] `docs/release-management/` (6 guides — document the dead tool's auth/config/env/troubleshooting)
+- [ ] `docs/examples/tutorials/01–06` + `docs/examples/integrations/` (github-actions.yml, gitlab-ci.yml, existing-project, migration-guide) + `docs/examples/README.md` release content — NOTE: if any example teaches consumer-side CI patterns worth salvaging, route content to the 123 install-doc effort instead of deleting blind
+- [ ] `docs/roadmap/release-system-review.md` (065-era; keep-as-history likely)
+
+### KEEP untouched (verify only)
+- [ ] Publish guard scripts (`check:drift`, `verify:token-index-clean`, `prepublishOnly` chain) — regression-check they run standalone
+- [ ] `docs/releases/` records; the hand-authored-notes practice
+- [ ] Spec 065 / 101 records (history)
+
+### Cross-spec notes
+- [ ] Record the "serve release notes to consumers?" question in 123's inbound set (per the ballot's C1 deferral)
+- [ ] If a U1b wave window is OPEN at execution time: this work's PRs are ordinary observed PRs (not instrument PRs — this is Q6 work, not 125-B measurement); no special handling


### PR DESCRIPTION
**Spec**: Q6 (parked question, chartered 2026-07-12 — Spec 125 design-outline §10)
**Unit**: standalone chore (decision record only — NO deletions in this PR)
**Agent**: Thurgood
**Validation**: docs-only; no test surface touched

## What this is
The record-first capture of this morning's ratified Q6 verdict: **retire the release manager; capture its surviving value as documentation.**

- **Ballot** (`.kiro/docs/ballots/2026-08-12-q6-release-manager-retirement.md`): the chartered audit evidence (v14.0.0 live trial, consumption trace, structural blindness), Peter's two concerns (what-changed-and-why discovery; dependency sweep) addressed IN scope, the verdict (kill / rewrite / archive / keep classes), counter-arguments on record.
- **Execution issue** (`.kiro/issues/2026-08-12-release-manager-retirement-execution.md`): the 36-file inventory as a per-file adjudication checklist — incl. the 2 always-loaded steering-law amendments, the mental-model doc rewrite with the discovery-chain section, and the 123 salvage/deferral notes. Executes in its own session; sweep re-runs at execution start.

## Effect at merge
The decision is law; nothing is deleted yet. Execution is authorized as issue-driven work whenever a session picks it up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)