### PR TITLE
Section-citation-resolution: register row + defect/checker issue (chore)

### DIFF
--- a/.kiro/issues/2026-08-12-release-manager-retirement-execution.md
+++ b/.kiro/issues/2026-08-12-release-manager-retirement-execution.md
@@ -44,7 +44,7 @@
 - [x] Untouched (history)
 
 ### Cross-spec notes
-- [x] DONE — `.kiro/specs/123-consumer-distribution/inbound-from-q6-release-retirement.md` authored (rides PR 2's fix push): notes-shipping deferral + the systemic internal-vs-consumer framing question, both routed to 123. **NEW from consult: (i) candidate register/U1b rule — "a get_section heading citation must resolve" (nothing mechanically guards cross-doc heading citations today); (ii) systemic internal-vs-consumer framing for the ~80 shipped governance docs → Spec 123's consumer-surface story.**
+- [x] DONE — `.kiro/specs/123-consumer-distribution/inbound-from-q6-release-retirement.md` authored (rides PR 2's fix push): notes-shipping deferral + the systemic internal-vs-consumer framing question, both routed to 123. **NEW from consult: (i) EXECUTED 2026-08-12 — register row `section-citation-resolution` (proposed) + defect/checker issue `2026-08-12-section-citation-defects-and-checker.md` (first scan: ~14 pre-existing dead citations); (ii) systemic internal-vs-consumer framing for the ~80 shipped governance docs → Spec 123's consumer-surface story.**
 - [ ] If a U1b wave window is OPEN at execution time: this work's PRs are ordinary observed PRs (not instrument PRs — this is Q6 work, not 125-B measurement); no special handling
 
 

--- a/.kiro/issues/2026-08-12-section-citation-defects-and-checker.md
+++ b/.kiro/issues/2026-08-12-section-citation-defects-and-checker.md
@@ -1,0 +1,41 @@
+# Issue: Dead get_section Citations — Defect Fixes + Checker Build
+
+**Date**: 2026-08-12
+**Authority**: register row `governance/classification-map.md § "section-citation-resolution"` (proposed; Peter ratifies at this PR's merge) — origin incident: the Q6 RMS-rewrite consult (Stacy caught 2 dead citations that only a chance consult surfaced), then the same-day corpus scan below proving the class pre-existed at scale.
+**Owner**: Thurgood coordinates; content fixes route by the three-layer boundary (steward flags → domain owner adjudicates); checker ARMING is Peter's flip.
+**Status**: OPEN — execute in a dedicated session. Re-run the scan at execution start (recipe below; counts are point-in-time).
+
+---
+
+## The scan (2026-08-12, first ever): 135 citations, 17 flagged, ~14 real
+
+Recipe (re-runnable): regex `get_section\(\{path:"X", heading:"Y"\}\)` over `governance/`, `.kiro/steering/`, `canonical/`; resolve X against served doc ids/filenames, Y against that doc's headings (substring). The execution session should use the D5 resolver chain (id → indexed path → legacy path → aliases) for precision.
+
+### Defect table (owner adjudication checklist)
+
+| # | Citing doc | Dead citation | Class | Owner | |
+|---|-----------|----------------|-------|-------|---|
+| 1–6 | `governance/Token-Quick-Reference.md` | `token-family-color` §§ "Identity Concept", "Action Concept", "Contrast Concept", "Structure Concept", "Component Tokens", "Primitive Color Families" | heading renamed/absent | **Ada** | [ ] |
+| 7 | same | `token-family-spacing` § "Spacing Scale" | heading absent | **Ada** | [ ] |
+| 8 | same | `token-family-typography` § "Typography Composition" | heading absent | **Ada** | [ ] |
+| 9 | same | `token-family-shadow` § "Shadow Scale" | heading absent | **Ada** | [ ] |
+| 10 | `governance/Component-Readiness-Status.md` | `component-family-form-inputs` § "Component Readiness" | heading absent | **Lina** | [ ] |
+| 11–12 | `.kiro/steering/Spec-Feedback-Protocol.md` | self-MCP-query examples (§§ "Stamp Format", "Mandatory @ Mention Scanning") | identity doc is never MCP-served — the example teaches a failing action | **Thurgood** | [ ] |
+| 13–14 | `.kiro/steering/Civitas-System-Overview.md` | self-MCP-query examples (+ `get_document_full`) | same identity-doc class | **Thurgood** | [ ] |
+| 15 | `governance/Process-File-Organization.md` | path-cite of `.kiro/steering/Civitas-System-Overview.md` § "Governance Processes" | citation INTO a never-served identity doc | **Thurgood** | [ ] |
+| — | `governance/Component-MCP-Document-Template.md` ×2 | `component-family-[family-name]` placeholders | NOT defects (template teaching the pattern) — checker must allowlist template placeholders | n/a | [x] |
+
+**Fix guidance**: heading-class → owner either restores/updates the cited heading or re-aims the citation (owner's content call). Identity-class → replace the MCP-example blocks with truthful access guidance (identity docs are always-loaded; MCP queries against them fail by design — 119 decision), or drop the blocks.
+
+## Checker build (after or with the fixes)
+
+- Resolver-chain-aware scanner (D5: id → indexed relative path → legacy path; plus aliases), heading-existence at citation grain, **identity-doc awareness** (any get_section/get_document_full citation targeting a never-served doc = defect), **template-placeholder allowlist** (`[family-name]`-style patterns).
+- Manual-run first against the fixed corpus (expect zero) → CI job → **gate-bite proof** (introduce a deliberate dead citation on a throwaway branch, observe red, close unmerged — the 125-A pattern) → **Peter flips it required** (his platform action = the arming).
+- **Timing (campaign law)**: arm BEFORE U1b wave 1's prune merges. After the campaign window opens, a new check arming is an exogenous boundary event (K=3 budget) — arming now is measurement-free.
+- Escalate-don't-build boundary: this checker is sanctioned BY the register row (proposed→armed path); keep it a single script + one CI job, no config system.
+
+## Cross-links
+
+- Register row: `governance/classification-map.md § "section-citation-resolution"`
+- Origin: Q6 execution issue § "Stacy consult record" (`2026-08-12-release-manager-retirement-execution.md`)
+- Related prior art: PR #111 (bare-id defects — the sibling class at link grain); 119-B OB-1 (cross-ref visibility)

--- a/governance/classification-map.md
+++ b/governance/classification-map.md
@@ -366,3 +366,21 @@ attribution:
 history:
   - { date: 2026-08-02, change: "entry created (119-B Task 1, unit U1 — window-free per R1 AC1; lands pre-measurement under the ratified R11 AC2 exception, with the keyword-shadowing check scheduled in the U2 case-study findings). Cite as governance/classification-map.md § 'certainty-calibration' (entry-id grammar, never count/position — R1 AC4). Drafted and landed by Thurgood per the steward-writes-register convention; pending Peter's ratification at the U1 merge. Evidence: .kiro/specs/119-B-capability-routing-measurement/completion/task-1-completion.md", by: thurgood }
 ```
+
+### section-citation-resolution
+
+```yaml
+rule: "A get_section heading citation in served or steering docs must resolve — the doc id must be MCP-served and the heading must exist on it"
+boundary_call:
+  class: functional
+  rationale: "Whether a citation resolves is a mechanical property of the artifact pair (id served + heading present) — no judgment; a dead citation silently withholds teaching from every agent that follows it"
+verification:
+  disposition: barrier
+  owner: thurgood
+  check_state: proposed
+  checks: ["PROPOSED: a resolver-chain-aware scanner (doc id/path/aliases per D5; heading existence; identity-doc awareness — an MCP citation TO a never-served identity doc is a defect by construction). Unarmed until built + gate-bite-proven; ARMING IS PETER'S FLIP (125-A pattern). Timing note: arm BEFORE U1b wave 1's prune merges — a new check arming after the campaign window opens is an exogenous boundary event"]
+education:
+  disposition: "No prose prune — this row records a NET-NEW verification need. Known defect class recorded 2026-08-12: first-ever scan found ~14 dead citations of 135 (Token-Quick-Reference ~10 [Ada], Component-Readiness-Status 1 [Lina], identity-doc self-MCP-query examples in Spec-Feedback-Protocol + Civitas-System-Overview [Thurgood — identity docs are deliberately never MCP-served, so those example blocks teach a failing action]). Fixes + checker build: .kiro/issues/2026-08-12-section-citation-defects-and-checker.md"
+history:
+  - { date: 2026-08-12, change: "entry created (steward, window-free — the certainty-calibration precedent) from the Q6-execution consult incident (Stacy caught two dead citations only because safeguard-2 happened to run) + the same-day corpus scan proving 14 pre-existing silent instances; evidence + adjudication table in the linked issue; check_state proposed — Peter ratifies the row at this PR's merge, the ARMING remains his separate flip", by: thurgood }
+```


### PR DESCRIPTION
**Spec**: register maintenance (living-register path — the certainty-calibration window-free precedent) + issue-driven execution charter
**Unit**: standalone chore (row + issue only; fixes and checker execute per the issue in a dedicated session)
**Agent**: Thurgood (steward-writes-register; Peter's merge ratifies the row)
**Validation**: docs-only; entry-id uniqueness + non-substring checked against all 12 existing ids

## What this records
- **Register row `section-citation-resolution` (check_state: proposed)** — the rule Stacy's Q6 consult surfaced: get_section citations must resolve. Evidence: the consult incident + today's first-ever corpus scan — **135 citations, ~14 dead** (Token-Quick-Reference ~10, Component-Readiness 1, identity-doc self-MCP-query examples 4-ish) — silent education decay, pre-existing, caught by chance.
- **Execution issue** with the full adjudication table (owner-routed: Ada / Lina / Thurgood), the checker build spec (resolver-chain-aware, identity-doc-aware, template-allowlisted), the gate-bite proof step, and the timing law: **arm BEFORE U1b wave 1's prune merges** (after the campaign window opens, a new arming is an exogenous boundary event — arming now is measurement-free).

## Effect at merge
The rule is remembered in the durable, MCP-served home; the fixes + checker are chartered for a dedicated session; **the ARMING remains your separate flip** after the gate-bite proof (125-A pattern).

## Coordination note
The wave-1 branch (`task/125-B-5-2-wave-1`) also appends register rows at the tail — its (c)-step will need a trivial rebase of the register append when it merges (noted in memory for the wave session).

🤖 Generated with [Claude Code](https://claude.com/claude-code)