### PR TITLE
Fix Avatar icon-size token family mislabel + family-mismatch guard (fix)

### DIFF
--- a/.kiro/issues/2026-08-13-component-token-platform-references-noncompiling.md
+++ b/.kiro/issues/2026-08-13-component-token-platform-references-noncompiling.md
@@ -1,0 +1,46 @@
+# Generated ComponentTokens platform files reference non-existent primitive classes
+
+**Date found**: 2026-08-13
+**Found during**: Avatar icon-size token family fix (follow-up to Button-Icon fix, PR #126) — Ada's generator audit
+**Owner**: Ada (Rosetta / generation pipeline)
+**Severity**: High — shipped generated output does not compile on iOS or Android (v14.0.0 affected)
+**Status**: OPEN
+
+---
+
+## The defect
+
+`TokenFileGenerator.getFamilyClassName()` (src/generators/TokenFileGenerator.ts) emits reference-path component token values as `<FamilyClass>.<primitiveName>`, e.g.:
+
+- iOS: `public static let sizeLarge: CGFloat = SizingTokens.size600`
+- Android: `val sizeLarge = SizingTokens.size600`
+
+But **no `SizingTokens` / `SpacingTokens` / `BorderWidthTokens` type exists in any generated or hand-written platform file**:
+
+- iOS primitives are flat statics on `struct DesignTokens` (`DesignTokens.size150`)
+- Android primitives are members of `object DesignTokens`, with underscores (`DesignTokens.size_150`)
+
+So `ComponentTokens.ios.swift` and `ComponentTokens.android.kt` **do not compile as shipped** (~29 dangling references each). PR #126 and the Avatar fix corrected the *family labels* (the reference now names the right family class), but the class itself still doesn't exist on either platform.
+
+**Compounding type mismatch**: Android emits sizing primitives as `Float` (`12f`) but spacing primitives as `Dp` (`12.dp`), so even a corrected member reference would type-mismatch `Dp`-typed consumers. Fixing requires a decision on platform API shape (member naming + type unification), not just a rename.
+
+## Related smaller defect (same surface)
+
+Web value-path component tokens emit **unitless** custom properties: `--avatar-icon-size-xs: 12`, `--verticallistitem-padding-block-rest: 11` (no `px`). No consumer reads these today, so it is latent. Symmetric fix: append `px` for dimensional families in `formatWebComponentTokenValue`; touches Avatar-Base and Button-VerticalList-Item output.
+
+## Why it stayed hidden
+
+No platform-side compile check exists for the generated component token files; the in-repo consumers (e.g. `Avatar.android.kt`) consume value-path tokens (raw literals, which do compile) or hand-written constants. The reference-path output has never been compiled by any check.
+
+## Scope for the fix (own session/spec — decisions needed)
+
+1. Decide platform API shape: should primitives be emitted as family-grouped types (`SizingTokens.size600`) or should component token references target the flat `DesignTokens` members that actually exist?
+2. Unify Android dimensional typing (`Dp` vs `Float`) across primitive families.
+3. Add a mechanical guard: a compile smoke-check of generated Swift/Kotlin output (the class of check that would have caught this years-scale latency).
+4. Web `px` suffix for dimensional value-path tokens.
+
+## Cross-references
+
+- PR #126 — Button-Icon family mislabel fix (reference path)
+- Avatar fix PR (branch `fix/avatar-icon-token-family`) — family-mismatch guard in `defineComponentTokens` now prevents *label* drift at authoring time; it cannot make the emitted class exist
+- `src/tokens/component/progress.ts` — the guard's first catch (one spacing-family call spanning three families)

--- a/src/build/tokens/__tests__/defineComponentTokens.test.ts
+++ b/src/build/tokens/__tests__/defineComponentTokens.test.ts
@@ -392,6 +392,119 @@ describe('defineComponentTokens', () => {
     });
   });
 
+  describe('Family-mismatch guard (reference path)', () => {
+    // A reference literal that carries `category`, as every real primitive in
+    // src/tokens/** does. The guard keys off this field.
+    const createMockPrimitiveWithCategory = (
+      name: string,
+      baseValue: number,
+      category: string
+    ): PrimitiveTokenReference => ({ name, baseValue, category });
+
+    test('throws when a reference primitive belongs to a different family than declared', () => {
+      const size600 = createMockPrimitiveWithCategory('size600', 48, 'sizing');
+
+      expect(() =>
+        defineComponentTokens({
+          component: 'ButtonIcon',
+          family: 'spacing',
+          tokens: {
+            'size.large': { reference: size600, reasoning: 'Large button size' },
+          },
+        })
+      ).toThrow(/Token family mismatch/);
+    });
+
+    test('error names the component, token, declared family, primitive and its real family', () => {
+      const size600 = createMockPrimitiveWithCategory('size600', 48, 'sizing');
+
+      let message = '';
+      try {
+        defineComponentTokens({
+          component: 'ButtonIcon',
+          family: 'spacing',
+          tokens: {
+            'size.large': { reference: size600, reasoning: 'Large button size' },
+          },
+        });
+      } catch (error) {
+        message = (error as Error).message;
+      }
+
+      expect(message).toContain("component 'ButtonIcon'");
+      expect(message).toContain("token 'size.large'");
+      expect(message).toContain("'spacing' family call");
+      expect(message).toContain("'size600'");
+      expect(message).toContain("'sizing' family");
+    });
+
+    test('regression: the real Button-Icon defect (PR #126) now fails at authoring time', () => {
+      // Before PR #126, buttonIcon.tokens.ts declared family 'spacing' while referencing
+      // sizing primitives. That produced `SpacingTokens.size600` — a member no generated
+      // platform file defines — and was caught only by reading generated Swift/Kotlin.
+      expect(() =>
+        defineComponentTokens({
+          component: 'ButtonIcon',
+          family: 'spacing',
+          tokens: {
+            'inset.large': {
+              reference: createMockPrimitiveWithCategory('space150', 12, 'spacing'),
+              reasoning: 'Correctly family-matched spacing token',
+            },
+            'size.large': {
+              reference: createMockPrimitiveWithCategory('size600', 48, 'sizing'),
+              reasoning: 'Mis-stamped sizing token — the defect',
+            },
+          },
+        })
+      ).toThrow(/references primitive 'size600' from the 'sizing' family/);
+    });
+
+    test('accepts a reference whose category matches the declared family', () => {
+      const size600 = createMockPrimitiveWithCategory('size600', 48, 'sizing');
+
+      const result = defineComponentTokens({
+        component: 'ButtonIcon',
+        family: 'sizing',
+        tokens: {
+          'size.large': { reference: size600, reasoning: 'Large button size' },
+        },
+      });
+
+      expect(result['size.large']).toBe(48);
+      expect((getTokenContract(result) ?? [])[0].family).toBe('sizing');
+    });
+
+    test('does not fire for reference literals without a category (back-compat)', () => {
+      const bareRef = createMockPrimitiveToken('space100', 8);
+
+      expect(() =>
+        defineComponentTokens({
+          component: 'ButtonIcon',
+          family: 'sizing',
+          tokens: {
+            'inset.small': { reference: bareRef, reasoning: 'Bare reference literal' },
+          },
+        })
+      ).not.toThrow();
+    });
+
+    test('does not fire for value-path tokens (the Avatar icon-size case is NOT covered)', () => {
+      // Documents a real limitation: the Avatar `icon.size.*` gap fillers were mis-stamped
+      // `family: 'spacing'` on the VALUE path. No reference exists to cross-check, so this
+      // guard cannot catch that class of mislabel.
+      expect(() =>
+        defineComponentTokens({
+          component: 'Avatar',
+          family: 'spacing',
+          tokens: {
+            'icon.size.xs': { value: 12, reasoning: 'Dimensional value in a spacing call' },
+          },
+        })
+      ).not.toThrow();
+    });
+  });
+
   describe('Idempotent re-branding (Spec 124, caveat c)', () => {
     test('re-applying the brand to the same return does not throw', () => {
       const result = defineComponentTokens({

--- a/src/build/tokens/defineComponentTokens.ts
+++ b/src/build/tokens/defineComponentTokens.ts
@@ -65,6 +65,16 @@ export interface PrimitiveTokenReference {
   name: string;
   /** Unitless base value from the primitive token */
   baseValue: number;
+  /**
+   * Primitive token family (the `category` field of a `PrimitiveToken`, e.g. 'spacing',
+   * 'sizing', 'radius'). OPTIONAL for backward compatibility: minimal `{ name, baseValue }`
+   * reference literals remain valid.
+   *
+   * When present, it is cross-checked against the call's declared `family` by the
+   * family-mismatch guard in {@link defineComponentTokens}. Real primitives from
+   * src/tokens/** always carry it, so the guard is active for all production authoring.
+   */
+  category?: string;
 }
 
 /**
@@ -216,8 +226,40 @@ export function defineComponentTokens<T extends Record<string, TokenDefinition>>
     if (isTokenWithReference(definition)) {
       // Token with primitive reference
       const primitiveToken = definition.reference;
+
+      // FAMILY-MISMATCH GUARD.
+      // The call's `family` is stamped onto every token it registers, and the generator
+      // derives platform output from it — notably the primitive class name used for
+      // reference-path tokens (getFamilyClassName) and the Android `.dp` suffix. A call
+      // that declares one family but references another family's primitive therefore emits
+      // a member that does not exist on the target platform. That is exactly the Button-Icon
+      // defect: a `family: 'spacing'` call referencing `sizingTokens.size600` generated
+      // `SpacingTokens.size600`, a non-existent member (PR #126).
+      //
+      // Only enforced when the reference carries a `category` — minimal `{ name, baseValue }`
+      // literals (used widely in tests) are intentionally exempt rather than rejected.
+      //
+      // Escape hatch: a token that legitimately needs another family's VALUE should use the
+      // value path (`value:`), which asserts no cross-family token-chain claim.
+      if (
+        typeof primitiveToken.category === 'string' &&
+        primitiveToken.category !== family
+      ) {
+        throw new Error(
+          `Token family mismatch in defineComponentTokens() for component '${component}': ` +
+          `token '${key}' is declared in a '${family}' family call but references primitive ` +
+          `'${primitiveToken.name}' from the '${primitiveToken.category}' family. ` +
+          `Every token in a call is stamped with that call's family, which drives platform ` +
+          `output (e.g. the generated '${family.charAt(0).toUpperCase() + family.slice(1)}Tokens' ` +
+          `class reference), so this would emit a non-existent platform member. ` +
+          `Fix: move '${key}' into a separate defineComponentTokens() call with ` +
+          `family: '${primitiveToken.category}', or use the value path if no token-chain ` +
+          `relationship is intended.`
+        );
+      }
+
       const value = primitiveToken.baseValue;
-      
+
       values[key] = value;
       registeredTokens.push({
         name: tokenName,

--- a/src/components/core/Avatar-Base/avatar.tokens.ts
+++ b/src/components/core/Avatar-Base/avatar.tokens.ts
@@ -33,7 +33,16 @@
  * Icon Size Derivations (in Avatar.web.ts):
  * - xs: calc(icon.size050 × 0.75) = 12px
  * - xxl: calc(icon.size050 × 4) = 64px
- * 
+ *
+ * TOKEN FAMILY: all dimensional Avatar tokens (container `size.*` AND icon
+ * `icon.size.*` gap fillers) are registered by the single sizing-family call
+ * `AvatarSizingTokens` below. The `icon.size.*` pair previously lived in a
+ * separate `AvatarTokens` call stamped `family: 'spacing'` — a mislabel, since
+ * both are dimensional sizing values. `AvatarTokens` is removed; consumers use
+ * `AvatarSizingTokens` or the `getAvatarIconSize()` / `getAvatarSize()` accessors.
+ * Generated platform output is unaffected: both calls declare `component: 'Avatar'`,
+ * so all tokens still land in one `AvatarTokens` Swift enum / Kotlin object.
+ *
  * COLOR TOKENS (Spec 058):
  * Avatar color tokens are defined in this file following the Rosetta System architecture
  * which mandates component tokens live at src/components/[ComponentName]/tokens.ts.
@@ -56,13 +65,24 @@ import { defineComponentTokens } from '../../../build/tokens';
 import { SIZING_BASE_VALUE, sizingTokens } from '../../../tokens/SizingTokens';
 
 /**
- * Avatar sizing tokens — container dimensions for each size variant.
+ * Avatar sizing tokens — container dimensions and icon dimensions for each size variant.
  *
  * Previously in a separate file (avatar-sizing.tokens.ts). Inlined to prevent
  * architectural anomaly (no other component splits tokens across files) and
  * simplify the package surface for sync.
  *
+ * ONE CALL PER FAMILY. Every token registered by a single defineComponentTokens()
+ * call is stamped with that call's `family`, and the family drives platform output
+ * (Swift type, Kotlin `.dp` suffix, primitive class name). The `icon.size.*` gap
+ * fillers below are dimensional sizing values, so they live in this sizing-family
+ * call — they were previously mis-stamped `family: 'spacing'` in a separate
+ * `AvatarTokens` call, the same latent mislabel class fixed for Button-Icon.
+ * Do NOT spread/merge this result with another call's result — the rich metadata
+ * rides on a non-enumerable brand (see src/build/tokens/defineComponentTokens.ts,
+ * TOKEN_CONTRACT_BRAND) that a spread would silently drop.
+ *
  * @see .kiro/specs/092-sizing-token-family/design.md
+ * @see src/components/core/Button-Icon/buttonIcon.tokens.ts for the two-call pattern
  */
 export const AvatarSizingTokens = defineComponentTokens({
   component: 'Avatar',
@@ -92,38 +112,15 @@ export const AvatarSizingTokens = defineComponentTokens({
       reference: sizingTokens.size1600,
       reasoning: 'Extra extra large avatar (128px). Full profile view, onboarding.',
     },
-  },
-});
 
-/**
- * Avatar component tokens defined using the hybrid authoring API.
- * 
- * Each token either references a primitive spacing token or uses a family-conformant
- * derivation, and includes reasoning explaining why the token exists.
- * 
- * NOTE: Web platform uses CSS calc() with icon tokens for sizing (see Avatar.styles.css).
- * These component tokens are primarily used for iOS/Android platforms and documentation.
- * 
- * Size token values:
- * - size.xs: 24px (3 × base, references size300)
- * - size.sm: 32px (4 × base, references size400)
- * - size.md: 40px (5 × base, references size500)
- * - size.lg: 48px (6 × base, references size600)
- * - size.xl: 80px (10 × base, derivation)
- * - size.xxl: 128px (16 × base, derivation)
- * 
- * Icon size token values (gap fillers - web uses calc() instead):
- * - icon.size.xs: 12px (1.5 × base, derivation) - web uses calc(icon.size050 × 0.75)
- * - icon.size.xxl: 64px (8 × base, derivation) - web uses calc(icon.size050 × 4)
- * 
- * @see Requirements 2.1-2.6, 3.1, 3.6 in .kiro/specs/042-avatar-component/requirements.md
- */
-export const AvatarTokens = defineComponentTokens({
-  component: 'Avatar',
-  family: 'spacing',
-  tokens: {
-    // Icon size tokens (gap fillers for sizes without existing icon tokens)
-    // These fill gaps where no standard icon token exists at the required 50% ratio
+    // Icon size tokens (gap fillers for sizes without an existing icon token).
+    // Kept on the VALUE path deliberately: sizing primitives exist at both values
+    // (size150 = 12, size800 = 64), but the reference path currently emits a
+    // fabricated `SizingTokens.<name>` class on iOS/Android that no generated or
+    // hand-written platform file defines. Switching these to `reference:` would
+    // trade compiling output (`12.dp`) for non-compiling output and break
+    // Avatar.android.kt's `val iconSizeXs: Dp = GeneratedAvatarTokens.iconSizeXs`.
+    // Revisit once TokenFileGenerator.getFamilyClassName emits a real platform type.
     'icon.size.xs': {
       value: SIZING_BASE_VALUE * 1.5,
       reasoning: 'Icon size for xs avatar (12px = 1.5× base) maintains 50% ratio (12/24). No existing icon token at this size, so component token fills the gap.',
@@ -273,7 +270,7 @@ export function getAvatarSize(variant: AvatarSizeVariant): number {
  * @see Requirements 3.1, 3.6 in .kiro/specs/042-avatar-component/requirements.md
  */
 export function getAvatarIconSize(variant: AvatarIconSizeVariant): number {
-  return AvatarTokens[`icon.size.${variant}`];
+  return AvatarSizingTokens[`icon.size.${variant}`];
 }
 
 /**

--- a/src/components/core/Avatar-Base/index.ts
+++ b/src/components/core/Avatar-Base/index.ts
@@ -11,7 +11,7 @@ export { AVATAR_DEFAULTS } from './types';
 
 // Token exports
 export {
-  AvatarTokens,
+  AvatarSizingTokens,
   getAvatarSize,
   getAvatarIconSize,
   getAvatarSizeTokenReference,

--- a/src/generators/TokenFileGenerator.ts
+++ b/src/generators/TokenFileGenerator.ts
@@ -565,6 +565,7 @@ export class TokenFileGenerator {
   private getiOSComponentTokenType(token: RegisteredComponentToken): string {
     switch (token.family) {
       case 'spacing':
+      case 'sizing':
       case 'radius':
       case 'fontSize':
       case 'tapArea':
@@ -619,8 +620,12 @@ export class TokenFileGenerator {
       const familyClass = this.getFamilyClassName(token.family);
       return `${familyClass}.${token.primitiveReference}`;
     }
-    // Dimensional families need .dp suffix to match primitive token output (Task 1.4)
-    const dimensionalFamilies = ['spacing', 'radius', 'tapArea', 'fontSize', 'borderWidth'];
+    // Dimensional families need .dp suffix to match primitive token output (Task 1.4).
+    // 'sizing' is dimensional (component width/height) and belongs here: without it, a
+    // value-path sizing token emits a bare Int, which fails to compile against consumers
+    // that type the member as Dp (e.g. Avatar.android.kt's
+    // `val iconSizeXs: Dp = GeneratedAvatarTokens.iconSizeXs`).
+    const dimensionalFamilies = ['spacing', 'sizing', 'radius', 'tapArea', 'fontSize', 'borderWidth'];
     if (dimensionalFamilies.includes(token.family)) {
       return `${token.value}.dp`;
     }

--- a/src/tokens/__tests__/ProgressTokenCompliance.test.ts
+++ b/src/tokens/__tests__/ProgressTokenCompliance.test.ts
@@ -22,18 +22,20 @@ import {
   PROGRESS_COLOR_TOKEN_COUNT,
 } from '../semantic/ColorTokens';
 import {
-  ProgressTokens,
+  getProgressRegisteredTokens,
   PROGRESS_COMPONENT_TOKEN_COUNT,
   progressComponentTokenNames,
 } from '../component/progress';
-import { getTokenContract } from '../../build/tokens';
 import type { RegisteredComponentToken } from '../../registries/ComponentTokenRegistry';
 
 // Spec 124: defineComponentTokens no longer self-registers into ComponentTokenRegistry;
 // the rich tokens ride back on the branded return and are recovered via getTokenContract.
 // (Was: reads of ComponentTokenRegistry.getByComponent('Progress') populated by the import
 // side effect — now empty/false-red.)
-const progressRegisteredTokens: RegisteredComponentToken[] = getTokenContract(ProgressTokens) ?? [];
+//
+// Progress registers through THREE family calls (sizing / spacing / borderWidth); the
+// helper concatenates their branded contracts in declaration order.
+const progressRegisteredTokens: RegisteredComponentToken[] = getProgressRegisteredTokens();
 
 describe('Progress Token Compliance', () => {
   // ==========================================================================

--- a/src/tokens/__tests__/ProgressTokenFormulas.test.ts
+++ b/src/tokens/__tests__/ProgressTokenFormulas.test.ts
@@ -13,7 +13,7 @@
  * @see .kiro/specs/048-progress-family/design.md (Size Variant, Current Size Formula)
  */
 
-import { ProgressTokens } from '../component/progress';
+import { progressTokenValues } from '../component/progress';
 import { SPACING_BASE_VALUE } from '../SpacingTokens';
 
 describe('Progress Token Formula Validation', () => {
@@ -52,8 +52,8 @@ describe('Progress Token Formula Validation', () => {
         const calculated = SPACING_BASE_VALUE * multiplier;
         expect(calculated).toBe(expected);
 
-        const tokenKey = `node.size.${size}.current` as keyof typeof ProgressTokens;
-        expect(ProgressTokens[tokenKey]).toBe(expected);
+        const tokenKey = `node.size.${size}.current` as keyof typeof progressTokenValues;
+        expect(progressTokenValues[tokenKey]).toBe(expected);
       }
     );
   });
@@ -66,12 +66,12 @@ describe('Progress Token Formula Validation', () => {
     ] as const)(
       'should maintain +4px offset for %s (base %dpx → current %dpx)',
       (size, base, current) => {
-        const baseKey = `node.size.${size}` as keyof typeof ProgressTokens;
-        const currentKey = `node.size.${size}.current` as keyof typeof ProgressTokens;
+        const baseKey = `node.size.${size}` as keyof typeof progressTokenValues;
+        const currentKey = `node.size.${size}.current` as keyof typeof progressTokenValues;
 
-        expect(ProgressTokens[baseKey]).toBe(base);
-        expect(ProgressTokens[currentKey]).toBe(current);
-        expect(ProgressTokens[currentKey] - ProgressTokens[baseKey]).toBe(4);
+        expect(progressTokenValues[baseKey]).toBe(base);
+        expect(progressTokenValues[currentKey]).toBe(current);
+        expect(progressTokenValues[currentKey] - progressTokenValues[baseKey]).toBe(4);
       }
     );
   });
@@ -84,9 +84,9 @@ describe('Progress Token Formula Validation', () => {
     ] as const)(
       'should align %s (%dpx) to 4px baseline grid',
       (tokenName, expected) => {
-        const tokenKey = tokenName as keyof typeof ProgressTokens;
-        expect(ProgressTokens[tokenKey]).toBe(expected);
-        expect(ProgressTokens[tokenKey] % 4).toBe(0);
+        const tokenKey = tokenName as keyof typeof progressTokenValues;
+        expect(progressTokenValues[tokenKey]).toBe(expected);
+        expect(progressTokenValues[tokenKey] % 4).toBe(0);
       }
     );
   });

--- a/src/tokens/__tests__/ProgressTokenTranslation.test.ts
+++ b/src/tokens/__tests__/ProgressTokenTranslation.test.ts
@@ -18,13 +18,15 @@
 
 import { TokenFileGenerator } from '../../generators/TokenFileGenerator';
 import { ComponentTokenRegistry } from '../../registries/ComponentTokenRegistry';
-import { getTokenContract } from '../../build/tokens';
 
 // Spec 124: defineComponentTokens no longer self-registers; the rich tokens ride back on
-// the branded return. We reproduce the production harvest here (recover via getTokenContract
+// the branded return. We reproduce the production harvest here (recover the rich tokens
 // + register into the canonical registry) so the real TokenFileGenerator pipeline — which
 // reads ComponentTokenRegistry.getAll() — has the Progress tokens to translate.
-import { ProgressTokens } from '../../tokens/component/progress';
+//
+// Progress registers through THREE family calls (sizing / spacing / borderWidth), so the
+// harvest is the concatenation helper rather than getTokenContract() of a single export.
+import { getProgressRegisteredTokens } from '../../tokens/component/progress';
 
 describe('Progress Token Cross-Platform Translation', () => {
   let generator: TokenFileGenerator;
@@ -34,7 +36,7 @@ describe('Progress Token Cross-Platform Translation', () => {
 
   beforeAll(() => {
     ComponentTokenRegistry.clear();
-    for (const token of getTokenContract(ProgressTokens) ?? []) {
+    for (const token of getProgressRegisteredTokens()) {
       ComponentTokenRegistry.register(token);
     }
 
@@ -91,27 +93,27 @@ describe('Progress Token Cross-Platform Translation', () => {
   describe('iOS Swift output includes progress current size tokens', () => {
     it('should reference size200 for sm current size', () => {
       expect(iosContent).toContain('nodeSizeSmCurrent');
-      expect(iosContent).toMatch(/nodeSizeSmCurrent.*SpacingTokens.size200/);
+      expect(iosContent).toMatch(/nodeSizeSmCurrent.*SizingTokens.size200/);
     });
 
     it('should reference size250 for md current size', () => {
       expect(iosContent).toContain('nodeSizeMdCurrent');
-      expect(iosContent).toMatch(/nodeSizeMdCurrent.*SpacingTokens.size250/);
+      expect(iosContent).toMatch(/nodeSizeMdCurrent.*SizingTokens.size250/);
     });
 
     it('should reference size300 for lg current size', () => {
       expect(iosContent).toContain('nodeSizeLgCurrent');
-      expect(iosContent).toMatch(/nodeSizeLgCurrent.*SpacingTokens.size300/);
+      expect(iosContent).toMatch(/nodeSizeLgCurrent.*SizingTokens.size300/);
     });
 
-    it('should use CGFloat type for spacing tokens', () => {
+    it('should use CGFloat type for dimensional tokens', () => {
       expect(iosContent).toMatch(/nodeSizeSmCurrent:\s*CGFloat/);
     });
 
     it('should reference SizingTokens for base size tokens', () => {
-      expect(iosContent).toContain('SpacingTokens.size150');
-      expect(iosContent).toContain('SpacingTokens.size200');
-      expect(iosContent).toContain('SpacingTokens.size250');
+      expect(iosContent).toContain('SizingTokens.size150');
+      expect(iosContent).toContain('SizingTokens.size200');
+      expect(iosContent).toContain('SizingTokens.size250');
     });
   });
 
@@ -122,23 +124,23 @@ describe('Progress Token Cross-Platform Translation', () => {
   describe('Android Kotlin output includes progress current size tokens', () => {
     it('should reference size200 for sm current size', () => {
       expect(androidContent).toContain('nodeSizeSmCurrent');
-      expect(androidContent).toMatch(/nodeSizeSmCurrent\s*=\s*SpacingTokens.size200/);
+      expect(androidContent).toMatch(/nodeSizeSmCurrent\s*=\s*SizingTokens.size200/);
     });
 
     it('should reference size250 for md current size', () => {
       expect(androidContent).toContain('nodeSizeMdCurrent');
-      expect(androidContent).toMatch(/nodeSizeMdCurrent\s*=\s*SpacingTokens.size250/);
+      expect(androidContent).toMatch(/nodeSizeMdCurrent\s*=\s*SizingTokens.size250/);
     });
 
     it('should reference size300 for lg current size', () => {
       expect(androidContent).toContain('nodeSizeLgCurrent');
-      expect(androidContent).toMatch(/nodeSizeLgCurrent\s*=\s*SpacingTokens.size300/);
+      expect(androidContent).toMatch(/nodeSizeLgCurrent\s*=\s*SizingTokens.size300/);
     });
 
     it('should reference SizingTokens for base size tokens', () => {
-      expect(androidContent).toContain('SpacingTokens.size150');
-      expect(androidContent).toContain('SpacingTokens.size200');
-      expect(androidContent).toContain('SpacingTokens.size250');
+      expect(androidContent).toContain('SizingTokens.size150');
+      expect(androidContent).toContain('SizingTokens.size200');
+      expect(androidContent).toContain('SizingTokens.size250');
     });
   });
 
@@ -149,9 +151,9 @@ describe('Progress Token Cross-Platform Translation', () => {
   describe('Cross-platform value consistency', () => {
     it('should reference same sizing primitives for current sizes across all platforms', () => {
       const currentSizes = [
-        { cssRef: 'size-200', swiftRef: 'SpacingTokens.size200', kotlinRef: 'SpacingTokens.size200', cssName: 'sm-current', camelName: 'nodeSizeSmCurrent' },
-        { cssRef: 'size-250', swiftRef: 'SpacingTokens.size250', kotlinRef: 'SpacingTokens.size250', cssName: 'md-current', camelName: 'nodeSizeMdCurrent' },
-        { cssRef: 'size-300', swiftRef: 'SpacingTokens.size300', kotlinRef: 'SpacingTokens.size300', cssName: 'lg-current', camelName: 'nodeSizeLgCurrent' },
+        { cssRef: 'size-200', swiftRef: 'SizingTokens.size200', kotlinRef: 'SizingTokens.size200', cssName: 'sm-current', camelName: 'nodeSizeSmCurrent' },
+        { cssRef: 'size-250', swiftRef: 'SizingTokens.size250', kotlinRef: 'SizingTokens.size250', cssName: 'md-current', camelName: 'nodeSizeMdCurrent' },
+        { cssRef: 'size-300', swiftRef: 'SizingTokens.size300', kotlinRef: 'SizingTokens.size300', cssName: 'lg-current', camelName: 'nodeSizeLgCurrent' },
       ];
 
       for (const { cssRef, swiftRef, kotlinRef, cssName, camelName } of currentSizes) {

--- a/src/tokens/component/progress.ts
+++ b/src/tokens/component/progress.ts
@@ -20,26 +20,45 @@
  * @see .kiro/specs/048-progress-family/design.md (Size Variant, Token Usage sections)
  */
 
-import { defineComponentTokens } from '../../build/tokens';
+import { defineComponentTokens, getTokenContract } from '../../build/tokens';
+import type { RegisteredComponentToken } from '../../registries/ComponentTokenRegistry';
 import { spacingTokens } from '../../tokens/SpacingTokens';
 import { sizingTokens } from '../../tokens/SizingTokens';
 import { borderWidthTokens } from '../../tokens/BorderWidthTokens';
 
 /**
- * Progress Indicator component tokens defined using the hybrid authoring API.
- * 
- * 13 tokens organized by concept:
+ * ONE CALL PER FAMILY.
+ *
+ * Every token registered by a single defineComponentTokens() call is stamped with that
+ * call's `family`, and the family drives platform output — notably the primitive class
+ * name emitted for reference-path tokens (TokenFileGenerator.getFamilyClassName) and the
+ * Android `.dp` suffix. These 10 tokens span THREE primitive families, so they require
+ * three calls. A single `family: 'spacing'` call previously produced
+ * `SpacingTokens.size150` / `SpacingTokens.borderWidth100` — members no generated platform
+ * file defines — the same defect fixed for Button-Icon in PR #126.
+ *
+ * The three branded results MUST NOT be spread/merged into one registration object: the
+ * rich metadata rides on a non-enumerable brand (src/build/tokens/defineComponentTokens.ts,
+ * TOKEN_CONTRACT_BRAND) that a spread silently drops. The harvest in loadComponentTokens
+ * collects each branded export separately. Use {@link progressTokenValues} for flat
+ * value lookups and {@link getProgressRegisteredTokens} for the rich metadata.
+ *
+ * All three calls declare `component: 'Progress'`, so platform output is still a single
+ * `ProgressTokens` Swift enum / Kotlin object.
+ */
+
+/**
+ * Node dimension tokens — reference sizing primitives (dimensions, not spacing).
+ *
  * - node.size.{sm|md|lg}         — base node dimensions
  * - node.size.{sm|md|lg}.current — emphasized node dimensions (+4px)
- * - node.gap.{sm|md|lg}          — spacing between nodes
- * - connector.thickness           — connector line width
  */
-export const ProgressTokens = defineComponentTokens({
+export const ProgressSizingTokens = defineComponentTokens({
   component: 'Progress',
-  family: 'spacing',
+  family: 'sizing',
   tokens: {
     // ========================================================================
-    // BASE NODE SIZES — reference sizing primitives (dimensions, not spacing)
+    // BASE NODE SIZES
     // ========================================================================
 
     'node.size.sm': {
@@ -56,7 +75,7 @@ export const ProgressTokens = defineComponentTokens({
     },
 
     // ========================================================================
-    // CURRENT NODE SIZES — reference sizing primitives directly (+4px emphasis)
+    // CURRENT NODE SIZES — +4px emphasis
     // Provides non-color visual differentiation of active position
     // ========================================================================
 
@@ -72,11 +91,18 @@ export const ProgressTokens = defineComponentTokens({
       reference: sizingTokens.size300,
       reasoning: 'Current node emphasis for lg (24px). +4px over base 20px for non-color visual differentiation.',
     },
+  },
+});
 
-    // ========================================================================
-    // GAP TOKENS — spacing between nodes (gaps are spacing, not sizing)
-    // ========================================================================
-
+/**
+ * Node gap tokens — reference spacing primitives (gaps are spacing, not sizing).
+ *
+ * - node.gap.{sm|md|lg} — spacing between nodes
+ */
+export const ProgressSpacingTokens = defineComponentTokens({
+  component: 'Progress',
+  family: 'spacing',
+  tokens: {
     'node.gap.sm': {
       reference: spacingTokens.space075,
       reasoning: 'Small gap between nodes (6px = 0.75× base). Tight spacing for compact pagination dots in mobile contexts.',
@@ -89,17 +115,53 @@ export const ProgressTokens = defineComponentTokens({
       reference: spacingTokens.space150,
       reasoning: 'Large gap between nodes (12px = 1.5× base). Generous spacing for detailed steppers with labels in desktop contexts.',
     },
+  },
+});
 
-    // ========================================================================
-    // CONNECTOR TOKENS — line connecting nodes in steppers
-    // ========================================================================
-
+/**
+ * Connector tokens — line connecting nodes in steppers. References a borderWidth primitive.
+ *
+ * - connector.thickness — connector line width
+ */
+export const ProgressBorderWidthTokens = defineComponentTokens({
+  component: 'Progress',
+  family: 'borderWidth',
+  tokens: {
     'connector.thickness': {
       reference: borderWidthTokens.borderWidth100,
       reasoning: 'Connector line thickness (1px). References borderDefault primitive for consistent border treatment across the design system.',
     },
   },
 });
+
+/**
+ * Flat value map across all three Progress token calls — a READ-ONLY convenience for
+ * value lookups (`progressTokenValues['node.size.md']`).
+ *
+ * NOT a registration surface: spreading drops the non-enumerable brand, so this object
+ * deliberately harvests to zero and cannot double-register. For the rich metadata use
+ * {@link getProgressRegisteredTokens}, never `getTokenContract(progressTokenValues)`.
+ */
+export const progressTokenValues = {
+  ...ProgressSizingTokens,
+  ...ProgressSpacingTokens,
+  ...ProgressBorderWidthTokens,
+};
+
+/**
+ * All Progress component tokens with their rich metadata, concatenated across the three
+ * family calls in declaration order (sizing → spacing → borderWidth).
+ *
+ * This is the brand-safe replacement for `getTokenContract(ProgressTokens)`, which is no
+ * longer meaningful now that Progress registers through three calls.
+ */
+export function getProgressRegisteredTokens(): RegisteredComponentToken[] {
+  return [
+    ...(getTokenContract(ProgressSizingTokens) ?? []),
+    ...(getTokenContract(ProgressSpacingTokens) ?? []),
+    ...(getTokenContract(ProgressBorderWidthTokens) ?? []),
+  ];
+}
 
 // ============================================================================
 // Constants and Utilities
@@ -135,19 +197,19 @@ export const progressComponentTokenNames = [
  * Validate that the progress component token count matches the expected count (13)
  */
 export function validateProgressComponentTokenCount(): boolean {
-  return Object.keys(ProgressTokens).length === PROGRESS_COMPONENT_TOKEN_COUNT;
+  return Object.keys(progressTokenValues).length === PROGRESS_COMPONENT_TOKEN_COUNT;
 }
 
 /**
  * Get a single progress component token value by key
  */
 export function getProgressComponentToken(key: string): number | undefined {
-  return (ProgressTokens as Record<string, number>)[key];
+  return (progressTokenValues as Record<string, number>)[key];
 }
 
 /**
  * Get all progress component token entries as key-value pairs
  */
 export function getAllProgressComponentTokens(): Array<{ name: string; value: number }> {
-  return Object.entries(ProgressTokens).map(([name, value]) => ({ name, value }));
+  return Object.entries(progressTokenValues).map(([name, value]) => ({ name, value }));
 }

--- a/token-index/components.yaml
+++ b/token-index/components.yaml
@@ -1,4 +1,12 @@
 tokens:
+  progress.connector.thickness:
+    component: Progress
+    primitiveReferences:
+      value: borderWidth100
+    platforms:
+      web: '--progress-connector-thickness'
+      ios: ProgressTokens.connectorThickness
+      android: ProgressTokens.connectorThickness
   progress.node.size.sm:
     component: Progress
     primitiveReferences:
@@ -71,14 +79,6 @@ tokens:
       web: '--progress-node-gap-lg'
       ios: ProgressTokens.nodeGapLg
       android: ProgressTokens.nodeGapLg
-  progress.connector.thickness:
-    component: Progress
-    primitiveReferences:
-      value: borderWidth100
-    platforms:
-      web: '--progress-connector-thickness'
-      ios: ProgressTokens.connectorThickness
-      android: ProgressTokens.connectorThickness
   avatar.size.xs:
     component: Avatar
     primitiveReferences:


### PR DESCRIPTION
**Spec**: n/a (issue-driven follow-up to PR #126, Button-Icon token family fix)
**Task**: Avatar-Base icon.size.xs / icon.size.xxl family mislabel + guard assessment
**Agent**: Ada (Opus, delegated) — verified in main session
**Completion doc**: n/a (non-spec fix; finding recorded in `.kiro/issues/2026-08-13-component-token-platform-references-noncompiling.md`)
**Validation**: `npx tsc --noEmit` clean; `npm test` 367 suites / 8897 tests passed (independently re-run in main session after delegation)

## What

1. **Avatar-Base relabel (the ask)**: `icon.size.xs`/`icon.size.xxl` were dimensional sizing gap-fillers stamped `family: 'spacing'`. Folded into the existing sizing-family `AvatarSizingTokens` call (kept on the value path — see in-file comment for why reference-path conversion would currently emit non-compiling output); removed the mislabeled `AvatarTokens` call. **Generated output byte-identical on all three platforms** — with the generator fix below.
2. **Generator**: added `'sizing'` to Android `dimensionalFamilies` (without it the relabel silently degrades `12.dp` → bare `12`, a Kotlin compile error vs `Avatar.android.kt`'s Dp-typed consumer) and to the iOS type switch.
3. **Family-mismatch guard (the 'consider a guard' ask)**: `defineComponentTokens()` now throws when a reference's primitive `category` differs from the declared `family` — this mechanically catches the Button-Icon defect class at authoring time (regression test included). Minimal `{name, baseValue}` literals stay exempt; value path is the documented escape hatch. 6 new unit tests; all 19 existing reference-path registrations pass.
4. **The guard's first catch**: `src/tokens/component/progress.ts` had one `family: 'spacing'` call spanning THREE families (6 sizing + 3 spacing + 1 borderWidth) — 7 broken generated members; the file's own comments and even two test *names* documented the correct intent while the assertions encoded the defect. Split into three family-correct calls; Progress tests retargeted (+87 tests that previously failed to load).

## Decisions for Peter at review

- **Breaking exports**: `AvatarTokens` → `AvatarSizingTokens`; `ProgressTokens` → three family exports + `progressTokenValues`. Precedent: PR #126, RELEASE-NOTES-11.3.1. Alternative (rejected but reversible): keep old names, change only the `family` stamp — zero-break but preserves the one-call-many-families anomaly.
- **Guard throws** (not warns). A warning would have let the Progress defect through; downgrade is a one-line change if preferred.
- **Systemic finding, deliberately NOT fixed here**: generated `ComponentTokens.ios.swift`/`.android.kt` reference primitive classes (`SizingTokens.*` etc.) that don't exist on any platform — they don't compile as shipped (v14.0.0 affected). Needs a platform-API-shape decision; recorded in `.kiro/issues/2026-08-13-component-token-platform-references-noncompiling.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)