### PR TITLE
fix: reconcile verify-gate-registration.sh drift — two later-armed contexts, count 16→18 (Civitas)

### DIFF
--- a/.kiro/issues/2026-08-21-gate-registration-drift-reconciliation.md
+++ b/.kiro/issues/2026-08-21-gate-registration-drift-reconciliation.md
@@ -1,0 +1,48 @@
+# Issue: verify-gate-registration.sh Drift Reconciliation + Sweep-5 Pending-Handback Ledger
+
+**Date**: 2026-08-21
+**Authority**: Peter's ruling 2026-08-21 (in-session, coordinator-relayed and executed same session): option (a) of the Civitas steward advisory — the sweep-5 Settings removal proceeds mid-window and **charges 1 of K=3** on the open 125-B U1b campaign window (campaign-measurement-protocol.md §2: a required-check-set change is an exogenous boundary event)
+**Owner**: Thurgood (Civitas steward); script/governance edits Peter-merged (governance carve-out); the Settings action is Peter-only
+**Status**: IN EXECUTION — script reconciliation in PR; **Peter Settings action PENDING** (this issue is the pending-handback ledger that the 2026-07-11 sweep-5 retirement lacked)
+
+---
+
+## The finding (verified live 2026-08-21)
+
+`tools/agent-generator/verify-gate-registration.sh` — the count-assert guard over `main`'s required-status-check contexts (Spec 122 Task 7.3, C9 / Req 20 AC3) — FAILED: expected 16 contexts, live protection had 19. Three discrepancies:
+
+1. **`Section Citation Guard`** — armed by Peter 2026-08-12 (register § "section-citation-resolution"); never added to `EXPECTED_CONTEXTS`.
+2. **`125B-tool-boot-smoke`** — armed 2026-07-14 (125-B Task 1.6; register § "tool-boot-smoke"); never added to `EXPECTED_CONTEXTS`.
+3. **`122-sweep-5-corrected-state`** — retired on record (Spec 122 U11 closeout, `task-18-parent-completion.md` § "Sweep-5 retirement", 2026-07-11) with the script side landed via PR #68 (commit `f652c3d3`) — but the **paired Peter Settings removal never landed**. Live config still carries the context.
+
+Context strings verified against the live protection API 2026-08-21 (the script's own printed `ACTUAL_CONTEXTS`): the literal strings are `Section Citation Guard` and `125B-tool-boot-smoke`.
+
+## Root causes (three distinct — full analysis in the steward advisory, this session)
+
+1. **Structural**: the script was never wired into `scripts/governance-check.sh --full` — its "run at the monthly health check" cadence lived only in a header comment, so the 2026-08-02 health check never ran it. (Fix: separate PR, `chore/wire-gate-registration-into-health-check`.)
+2. **Process**: arming a required check carried no paired obligation to update `EXPECTED_CONTEXTS` in the same recorded change (the script's failure message states the rule, but only fires when run — see 1). Both armings missed it.
+3. **Half-executed two-actor change**: sweep-5's retirement needed agent-side (script, landed PR #68) + Peter-side (Settings, never landed); no pending-handback ledger tracked the Peter half. This issue IS that ledger, retroactively.
+
+## Checklist
+
+### Reconciliation (agent side)
+- [x] Script updated: `EXPECTED_CONTEXTS` + `125B-tool-boot-smoke` + `Section Citation Guard`; `EXPECTED_COUNT` 16 → 18; header rewritten to record the reconciliation (this issue's PR, `fix/gate-registration-drift-reconciliation`)
+- [x] Register history appends: `tool-boot-smoke` row + `section-citation-resolution` row (same PR)
+- [x] Post-edit verify-run: script fails on EXACTLY one thing — the extra sweep-5 context (the precise pending-action signal; output in the PR body)
+
+### PENDING — Peter Settings action (Step 2 of the advisory)
+- [ ] **Peter**: Settings → Branches → `main` protection → required status checks → **remove `122-sweep-5-corrected-state`**. This is the C9-recorded protection-list change deferred since 2026-07-11.
+
+### Step 3 — verify-run after the removal (same burst)
+- [ ] **Thurgood** (or Peter): run `./tools/agent-generator/verify-gate-registration.sh` → expect `PASS: all 18 required contexts present`. Record the PASS here (date + output line) to close this ledger's sweep-5 item.
+
+### 125-B campaign-window accounting
+- [ ] **Thurgood**: at the NEXT observation pass after the removal lands, record the boundary event in `.kiro/specs/125-B-classification-map/completion/u1b/campaign-window-dataset.md` — exogenous required-check-set change, charges **1 of K=3**, segments the shared campaign window (Peter's option-(a) ruling, 2026-08-21). NOT recorded pre-emptively; the dataset entry is made at the observation pass, per campaign law's event-anchored cadence.
+- Note: the §4 FROZEN scoring set (18, incl. sweep-5) is unaffected — frozen means frozen; post-removal, sweep-5 simply stops appearing on new pinned SHAs ("present on the pinned SHA" handles absence). The charge is the segmentation, not a scoring change.
+
+### Follow-up (separate PR, independent files)
+- [ ] Wire `verify-gate-registration.sh` into `scripts/governance-check.sh --full` (`chore/wire-gate-registration-into-health-check`) so the monthly cadence is mechanical, not a comment.
+
+## Rule restated (for future armings/retirements)
+
+Arming OR retiring a required check updates `verify-gate-registration.sh`'s `EXPECTED_CONTEXTS` **in the same recorded change** (C9). For two-actor changes (agent script edit + Peter Settings action), open a pending-handback ledger entry (this pattern) so the second half cannot evaporate. 125-B U3's arming procedure should bake this step in (flagged to the U3 plan).

--- a/governance/classification-map.md
+++ b/governance/classification-map.md
@@ -210,6 +210,7 @@ education:
   disposition: "nothing to prune — no prose predecessor"
 history:
   - { date: 2026-07-14, change: "entry created (U1-s pilot substrate, Task 1.6); check wired: .github/workflows/tool-boot-smoke.yml + tests/tool-boot-smoke.test.ts; local run 49/49 passing incl. Product MCP passing index-empty (Req 5.2); side-effect confirmation + gate-bite proof plan recorded in .kiro/specs/125-B-classification-map/completion/task-1-6-completion.md", by: thurgood }
+  - { date: 2026-08-21, change: "context 125B-tool-boot-smoke added to verify-gate-registration.sh EXPECTED_CONTEXTS (drift reconciliation — the 2026-07-14 arming never updated the count-assert in the same recorded change; record: .kiro/issues/2026-08-21-gate-registration-drift-reconciliation.md, applied via this entry's PR)", by: thurgood }
 ```
 
 ### no-autonomous-token-creation
@@ -384,6 +385,7 @@ education:
 history:
   - { date: 2026-08-12, change: "entry created (steward, window-free — the certainty-calibration precedent) from the Q6-execution consult incident (Stacy caught two dead citations only because safeguard-2 happened to run) + the same-day corpus scan proving 14 pre-existing silent instances; evidence + adjudication table in the linked issue; check_state proposed — Peter ratifies the row at this PR's merge, the ARMING remains his separate flip", by: thurgood }
   - { date: 2026-08-12, change: "row ratified at PR #122's merge (per the creation entry's own terms). PR #122 built the checker and fixed all 18 defects found by the resolver-chain-aware re-scan (183 citations checked; the issue table's ~15 plus one new exact-match catch, row 16 / Web-Authoring-Standards) — post-fix corpus 173 citations, 0 defects. Gate-bite proven red on throwaway PR #121 (one deliberate dead citation; run https://github.com/3fn/DesignerPunk/actions/runs/31608088052/job/94152123200), closed unmerged. Peter flipped \"Section Citation Guard\" required on main branch protection the same day, BEFORE U1b wave 1's prune merges — measurement-free per campaign law (no window open yet; not a boundary-event charge). check_state: proposed -> armed", by: thurgood }
+  - { date: 2026-08-21, change: "context \"Section Citation Guard\" added to verify-gate-registration.sh EXPECTED_CONTEXTS (drift reconciliation — the 2026-08-12 arming never updated the count-assert in the same recorded change; record: .kiro/issues/2026-08-21-gate-registration-drift-reconciliation.md, applied via this entry's PR)", by: thurgood }
 ```
 
 ### commit-to-main-via-pr-only

--- a/tools/agent-generator/verify-gate-registration.sh
+++ b/tools/agent-generator/verify-gate-registration.sh
@@ -3,20 +3,33 @@
 #
 # Queries the branch-protection API and COUNT-ASSERTS the required-status-check context
 # set: the NINE standing 122 contexts PLUS the seven pre-existing contexts (Consumer Guard,
-# package drift, the five 125-A lanes) — per inbound-from-125-A-arming.md (the handback ACTION).
+# package drift, the five 125-A lanes) — per inbound-from-125-A-arming.md (the handback ACTION) —
+# PLUS the two later-armed contexts (125B-tool-boot-smoke, Section Citation Guard; see below).
 # The Item-13 sweep precedent applied to ourselves: a required check that silently fell off
 # the protection list is exactly the drift class Spec 122 exists to kill.
 #
 # Run at each cutover + the monthly governance health check (Thurgood).
 #
+# DRIFT RECONCILIATION (2026-08-21, Civitas steward audit): this script was stale/failing from
+# 2026-07-14 until this change because two later-armed required checks were never added to the
+# expected set in the same recorded change as their arming:
+#   - "125B-tool-boot-smoke" — armed 2026-07-14 (125-B U1-s pilot substrate, Task 1.6;
+#     register row: governance/classification-map.md § "tool-boot-smoke")
+#   - "Section Citation Guard" — armed 2026-08-12 (Peter's Settings flip; register row:
+#     governance/classification-map.md § "section-citation-resolution")
+# Both are now counted (16 → 18). Root causes and the reconciliation record:
+# .kiro/issues/2026-08-21-gate-registration-drift-reconciliation.md. Rule restated: arming OR
+# retiring a required check updates EXPECTED_CONTEXTS in the SAME recorded change (C9).
+#
 # SWEEP-5 RETIRED (Spec 122 Task 18 / U11 closeout, 2026-07-11): 122-sweep-5-corrected-state was
 # a PRE-CUTOVER-WINDOW-ONLY gate (Req 19 AC1 exception; re-entry protection lives in the standing
-# class checks). All cutovers are done, so its context is removed from branch protection (Peter's
-# Settings action) and re-counted here IN THE SAME recorded protection-list change (C9) — 17 → 16,
-# ten → nine 122 contexts. NOTE: this script must MATCH the live protection list; if it is run
-# before the Settings removal lands, it will (correctly) FAIL on the extra sweep-5 context — sync
-# the two. The sweep-5 workflow JOB may keep running as a NON-required check (harmless) until
-# separately removed.
+# class checks). The script side landed 2026-07-11 (PR #68), but the PAIRED Peter Settings action
+# (removing the context from branch protection) is STILL PENDING as of 2026-08-21 — ruled
+# option (a) by Peter 2026-08-21 (charges 1 of K=3 on the open 125-B campaign window; see the
+# issue doc). Until that removal lands, this script (correctly) FAILS on exactly one thing: the
+# extra sweep-5 context — that single failure IS the pending-action signal. After the removal,
+# it PASSES at 18. The sweep-5 workflow JOB may keep running as a NON-required check (harmless)
+# until separately removed.
 #
 # Auth: GITHUB_TOKEN from the environment, falling back to the repo-root .env. The
 # repo-root PAT can READ/PATCH protection (it cannot dispatch workflows — 403; that
@@ -63,8 +76,11 @@ EXPECTED_CONTEXTS=(
   "122-sweep-6-declarations"
   "122-sweep-7-dispositions"
   "122-sweep-8-demotion"
+  # Later-armed required checks (2026-08-21 drift reconciliation — see header):
+  "125B-tool-boot-smoke"     # armed 2026-07-14 (125-B Task 1.6)
+  "Section Citation Guard"   # armed 2026-08-12 (Peter's flip; register § section-citation-resolution)
 )
-EXPECTED_COUNT=16
+EXPECTED_COUNT=18
 
 # ── Query ────────────────────────────────────────────────────────────────────
 ACTUAL_JSON="$(curl -sfL \


### PR DESCRIPTION
**Spec**: (non-spec, issue-driven) — `.kiro/issues/2026-08-21-gate-registration-drift-reconciliation.md`
**Task**: Gate-registration drift reconciliation, Step 1 of the Civitas steward advisory (2026-08-21)
**Agent**: Thurgood
**Completion docs**: the issue doc above (pending-handback ledger; rides this PR)
**Validation**: `bash -n` clean; script run live against branch protection post-edit — see evidence below

## What changed

`tools/agent-generator/verify-gate-registration.sh` had been stale/failing since 2026-07-14: two later-armed required checks were never added to its count-asserted expected set in the same recorded change as their arming, and the 2026-07-11 sweep-5 retirement (PR #68) landed only its script half — the paired Peter Settings removal never happened. Advisory findings (this session): three root causes — (1) the script is not wired into `governance-check.sh --full` (separate PR follows); (2) no arming-updates-the-count-assert pairing obligation; (3) a half-executed two-actor change with no pending-handback ledger.

- `EXPECTED_CONTEXTS` + `"125B-tool-boot-smoke"` (armed 2026-07-14, register § tool-boot-smoke) + `"Section Citation Guard"` (armed 2026-08-12, register § section-citation-resolution) — exact live API strings, verified against the script's own printed `ACTUAL_CONTEXTS`
- `EXPECTED_COUNT` 16 → 18; header rewritten to record the reconciliation and the PENDING sweep-5 Settings removal (Peter's option-(a) ruling 2026-08-21: proceeds mid-window, charges 1 of K=3)
- `governance/classification-map.md`: one-line history appends on the two rows
- `.kiro/issues/2026-08-21-gate-registration-drift-reconciliation.md`: the pending-handback ledger (Peter's Settings action + Step-3 verify-run + the campaign-window boundary-event recording, owned by Thurgood at the next observation pass)

## Post-edit live run (the predicted precise-signal state — fails on EXACTLY the sweep-5 extra)

```
registered contexts (19):
  [... 19 contexts ...]
FAIL: UNEXPECTED required context on the protection list (update this script IN the same recorded change if intentional): "122-sweep-5-corrected-state"
FAIL: count-assert — expected 18 required contexts, found 19
EXIT=1
```

No MISSING failures — both new context strings matched live. After Peter removes `122-sweep-5-corrected-state` in Settings, the script PASSES at 18.

## 125-B window note

This PR is an ordinary observed PR in the open Wave-1 window (not instrumentation, not a boundary event). The boundary-event charge belongs to Peter's Settings removal, recorded in the campaign dataset at the next observation pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
