### PR TITLE
chore: wire verify-gate-registration.sh into governance-check.sh --full (Civitas)

### DIFF
--- a/scripts/governance-check.sh
+++ b/scripts/governance-check.sh
@@ -94,6 +94,27 @@ if [ -n "$AGENT_CHANGES" ] || [ "$FULL_CHECK" = true ]; then
   echo ""
 fi
 
+# === Trigger 5: Gate registration (branch protection count-assert) — --full only ===
+# Wired 2026-08-21 (drift reconciliation — .kiro/issues/2026-08-21-gate-registration-drift-reconciliation.md):
+# the instrument's "run at the monthly health check" cadence previously lived only in its own
+# header comment, so the orchestrator never ran it and its 2026-07/08 drift went undetected.
+# Report-and-continue (FINDINGS=1), matching every other instrument here — a red gate-registration
+# is a finding for the steward to route, not a reason to abort the remaining checks.
+# KNOWN STATE until Peter's pending sweep-5 Settings removal lands (see the issue doc): this step
+# reports exactly one failure — the extra 122-sweep-5-corrected-state context. That single failure
+# IS the pending-action signal; it clears when the removal lands.
+if [ "$FULL_CHECK" = true ]; then
+  echo "## 5. Gate Registration (branch protection)"
+  echo ""
+  GATE_SCRIPT="$SCRIPTS_DIR/../tools/agent-generator/verify-gate-registration.sh"
+  if [ -x "$GATE_SCRIPT" ]; then
+    "$GATE_SCRIPT" 2>&1 || FINDINGS=1
+  else
+    echo "⚠️  verify-gate-registration.sh not found or not executable"
+  fi
+  echo ""
+fi
+
 # === Summary ===
 echo "---"
 if [ "$FINDINGS" -eq 0 ]; then


### PR DESCRIPTION
**Spec**: (non-spec, issue-driven) — `.kiro/issues/2026-08-21-gate-registration-drift-reconciliation.md` (rides PR #128)
**Task**: Gate-registration drift reconciliation, Step 4 of the Civitas steward advisory (2026-08-21)
**Agent**: Thurgood
**Validation**: `bash -n` clean; `governance-check.sh --full` dry-run confirmed the new step invokes the instrument and sets FINDINGS (start-up-tasks date side effect reverted, not committed)

## What changed

Root cause (1) of the drift finding: `verify-gate-registration.sh`'s "run at each cutover + the monthly governance health check" cadence lived only in its own header comment — `governance-check.sh` never referenced it (grep-verified across `scripts/` and `.kiro/hooks/`), so the 2026-08-02 health check structurally could not catch the expected-set drift. This wires it in as step "## 5. Gate Registration (branch protection)", gated on `--full` (the monthly-check mode; the non-full fast path is a steering/agent-config delta check where branch protection is out of scope).

## Hard-fail vs report-and-continue: chose REPORT-AND-CONTINUE

Every other instrument in the orchestrator is invoked as `<instrument> || FINDINGS=1` — failures are collected, the summary reports "Issues found", and the script exits 1 without aborting later steps. I matched that convention: a red gate-registration is a finding for the steward to route (and, for a real fell-off-the-list event, an urgent one), not a reason to skip the remaining instruments. Hard-fail would also make the health check unable to complete during the known pending-sweep-5 interval, which is exactly the alarm-fatigue state this reconciliation is killing. Exit code still goes to 1 on any finding, so nothing is swallowed.

## Known state until Peter's sweep-5 Settings removal lands

Documented in the wiring comment: after PR #128 merges, this step reports exactly ONE failure (the extra `122-sweep-5-corrected-state` context) — the pending-action signal — and clears to `PASS: all 18` once the removal lands. (On this branch's dry-run it showed three failures because the branch still carries the pre-#128 script; the two are independent files, not stacked.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
