### PR TITLE
Verification-grade standard for routed doc reviews (chore)

### DIFF
--- a/.kiro/docs/civitas-health-checks/2026-08-25.md
+++ b/.kiro/docs/civitas-health-checks/2026-08-25.md
@@ -48,3 +48,13 @@
 | Return edge | Clean — no new signal; windows standing |
 | Date marker | Auto-updated to 2026-08-25 |
 | Carried items | AI-Collaboration-Framework review (2nd cycle); issues-dir triage (new) |
+
+---
+
+## Addendum (2026-08-25, same session — Peter-ratified): §3 reviews upgraded to VERIFICATION-GRADE
+
+The 12 review-age reviews routed in §3 are **claims-vs-source verification reviews, not read-throughs** — ruled by Peter after this burst's evidence that plausibility reviews don't catch drift (the stale TQR section survived a review stamp; the family-doc names survived months of use; the CDS field list survived post-063 unchanged).
+
+**The standard**: for each doc, verify its factual claims against ground truth — contract names against `contracts.yaml`, token values/formulas against the token source, field lists against the live validators, file/line citations against code, pipeline claims against the generators. `Last Reviewed` updates ONLY after claims verify (or defects are filed/fixed). A review that reads for plausibility does not clear the flag.
+
+**One sequencing rule + one queued item**: Ada's `DTCG-Integration-Guide` / `Figma-Workflow-Guide` reviews remain PAIRED AFTER the dual-color-source divergence session (verifying color-pipeline claims before that decision wastes the review); a **Token-Family-*.md claims-vs-source pass** is queued for after the same session (spot-check evidence this burst: Token-Family-Color's pink400 values verify exactly — the family docs look healthier than the component docs were, but one sample is not a bill of health). If the scheduled instruments still surface drift after running, the durable fix is a standing quarterly verification sweep inside this health check — deferred until that evidence exists.

--- a/.kiro/issues/2026-08-25-contract-education-content-debt.md
+++ b/.kiro/issues/2026-08-25-contract-education-content-debt.md
@@ -42,6 +42,10 @@ Avatar `error_handling` + `wrapper_delegation`; Container(CIS) `responsive_layou
 - CIS's self-disclaimed planned sections and the four placeholder family docs (Divider/Loading/Modal/Data-Display) — aspirational, self-disclaiming, MCP named authoritative; editing them would launder them into looking settled.
 - Concept Catalog bare names in Contract-System-Reference and historical-record uses (register history, adjudication prose) — correct by design.
 
+## Review standard for the paired review-age reviews (added 2026-08-25, Peter-ratified)
+
+The 7 component-doc reviews routed to Lina at the 2026-08-25 health check (§3 + Addendum) naturally pair with this batch and are **verification-grade**: factual claims checked against source (names vs contracts.yaml, field lists vs live validators, citations vs code) — not plausibility read-throughs. `Last Reviewed` updates only after claims verify. Full standard: `.kiro/docs/civitas-health-checks/2026-08-25.md` § Addendum.
+
 ## Done criteria
 
 Each item lands via its own PR (or small coherent groups), normal review; item 2's validator extension proves its bite (mutation red/green) before the sweep is called closed; docs-MCP reindex after any served-surface change. This issue closes when items 2–5 are each resolved-or-explicitly-parked with a dated note here.


### PR DESCRIPTION
**Spec**: none — Peter's ruling 2026-08-25 (in-session, at burst close)
**Agent**: Claude (main loop, steward)
**Validation**: docs-only (health-check addendum + batch-ledger note)

Upgrades the 12 review-age reviews routed at today's health check to **claims-vs-source verification grade** — the burst's three drift catches all survived plausibility-style review, so the standard now requires verifying names/values/field-lists/citations against source before a review clears the flag. Adds the post-divergence-session Token-Family verification pass to the queue; defers a standing quarterly sweep until the scheduled instruments prove insufficient.

🤖 Generated with [Claude Code](https://claude.com/claude-code)