### PR TITLE
README: version badge 12.0.5 → 14.1.0 (chore)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # DesignerPunk
 
-[![Version](https://img.shields.io/badge/Version-12.0.5-purple)](docs/releases/RELEASE-NOTES-12.0.0.md)
+[![Version](https://img.shields.io/badge/Version-14.1.0-purple)](docs/releases/release-14.1.0.md)
 [![Repository](https://img.shields.io/badge/GitHub-DesignerPunk-blue)](https://github.com/3fn/DesignerPunk)
 [![License](https://img.shields.io/badge/License-Apache--2.0-green.svg)](LICENSE)
 [![TypeScript](https://img.shields.io/badge/TypeScript-5.0+-blue.svg)](https://www.typescriptlang.org/)
-[![Tests](https://img.shields.io/badge/Tests-8936%2B-brightgreen)](.)
+[![Tests](https://img.shields.io/badge/Tests-8892%2B-brightgreen)](.)
 
 ---
 


### PR DESCRIPTION
**Spec**: none — release-day hygiene (Peter's catch: the badge was missed through TWO releases and has read 12.0.5 since June)
**Agent**: Claude (main loop)
**Validation**: docs-only; badge now links to the current release notes; tests count refreshed to the current functional-lane total

Release-checklist note: 'update the README version badge' should join the manual publish playbook so this doesn't miss a third release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)